### PR TITLE
NuGet-Checker.yml -> regenerate-sources.yml, workflow is now complete

### DIFF
--- a/.github/workflows/NuGet-Checker-2.yml
+++ b/.github/workflows/NuGet-Checker-2.yml
@@ -52,23 +52,30 @@ jobs:
 
     - name: Set ENV Variables
       run: |
-        # TEST
-        #"$GITHUB_ENV" <<< "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})"
         # Freedesktop SDK runtime rersion, example: 24.08
         echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
-        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})"
-        echo "YQ_DOTNETSDK=${YQ_DOTNETSDK}" >> "$GITHUB_ENV"
-        #echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
-        # Jellyfin tag
+        # Jellyfin tag, example: 10.10
         echo "YQ_TAG=$(yq '.modules[-1].sources[2].tag' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
-        #"$GITHUB_ENV" <<< "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}"
+        # DotNet SDK, example: org.freedesktop.Sdk.Extension.dotnet8
+        echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        # DotNet version, example: 8
+        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})"
         echo "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}" >> "$GITHUB_ENV"
+        # Node SDK, example: org.freedesktop.Sdk.Extension.node22
+        echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
 
     - name: Checkout Jellyfin
       uses: actions/checkout@v4
       with:
         repository: jellyfin/jellyfin
         path: jellyfin
+        ref: ${{ env.YQ_TAG }}
+
+    - name: Checkout Jellyfin Web
+      uses: actions/checkout@v4
+      with:
+        repository: jellyfin/jellyfin-web
+        path: jellyfin-web
         ref: ${{ env.YQ_TAG }}
 
     - name: Checkout Flatpak Builder Tools
@@ -80,10 +87,11 @@ jobs:
     - name: Install Freedesktop SDK and DotNet Runtime
       run: |
         flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak update --noninteractive -y
+        flatpak update --user --noninteractive -y
         flatpak install --user flathub org.flatpak.Builder --noninteractive -y
         flatpak install --user flathub org.freedesktop.Sdk//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         flatpak install --user flathub ${{ env.YQ_DOTNETSDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
+        flatpak install --user flathub {{ env.YQ_NODESDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         
     - name: Generate cache for NuGet x64
       run: |
@@ -98,6 +106,11 @@ jobs:
           --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.RUNTIME_VER }} --runtime=linux-arm64 \
           main/nuget-generated-sources-arm64.json \
           jellyfin/Jellyfin.Server/Jellyfin.Server.csproj
+
+    - name: Generate cache for Node
+      run: |
+        ./flatpak-builder-tools/node/flatpak-node-generator \
+        -o "main/npm-generated-sources.json" npm "jellyfin-web/package-lock.json"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5

--- a/.github/workflows/NuGet-Checker-2.yml
+++ b/.github/workflows/NuGet-Checker-2.yml
@@ -91,7 +91,7 @@ jobs:
         flatpak install --user flathub org.flatpak.Builder --noninteractive -y
         flatpak install --user flathub org.freedesktop.Sdk//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         flatpak install --user flathub ${{ env.YQ_DOTNETSDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
-        flatpak install --user flathub {{ env.YQ_NODESDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
+        flatpak install --user flathub ${{ env.YQ_NODESDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         
     - name: Generate cache for NuGet x64
       run: |

--- a/.github/workflows/NuGet-Checker-2.yml
+++ b/.github/workflows/NuGet-Checker-2.yml
@@ -15,7 +15,8 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         path: main
 
@@ -38,25 +39,26 @@ jobs:
 
     - name: Setup Dependencies Flatpak
       run: |
-        sudo apt update -y
-        sudo apt install flatpak -y
+        sudo apt-get update -y
+        sudo apt-get install flatpak -y --no-install-recommends
 
     - name: Setup Dependencies yq
       run: |
         mkdir -pv ~/.local/bin
-        wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ~/.local/bin/yq
+        wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ~/.local/bin/yq
         chmod -v +x ~/.local/bin/yq
 
     - name: Set ENV Variables
       run: |
         # TEST
-        "$GITHUB_ENV" <<< "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})"
+        #"$GITHUB_ENV" <<< "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})"
         # Freedesktop SDK runtime rersion, example: 24.08
         echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
         echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
         # Jellyfin tag
         echo "YQ_TAG=$(yq '.modules[-1].sources[2].tag' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
-        "$GITHUB_ENV" <<< "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}"
+        #"$GITHUB_ENV" <<< "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}"
+        echo "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}" >> "$GITHUB_ENV"
 
     - name: Checkout Jellyfin
       uses: actions/checkout@v4

--- a/.github/workflows/NuGet-Checker-2.yml
+++ b/.github/workflows/NuGet-Checker-2.yml
@@ -1,4 +1,4 @@
-name: NuGet Checker
+name: NuGet Checker 2024
 
 on:
   #schedule:
@@ -26,6 +26,8 @@ jobs:
         if [[ -n "$(git ls-remote --heads origin update-nuget)" ]]; then
           echo "Warning: Branch 'update-nuget' exists. Merge the PR or delete the branch."
           exit 1
+        else
+          echo "OK: Branch not found."
         fi
 
     - name: Restore Flatpak Cache
@@ -54,7 +56,9 @@ jobs:
         #"$GITHUB_ENV" <<< "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})"
         # Freedesktop SDK runtime rersion, example: 24.08
         echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
-        echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})"
+        echo "YQ_DOTNETSDK=${YQ_DOTNETSDK}" >> "$GITHUB_ENV"
+        #echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
         # Jellyfin tag
         echo "YQ_TAG=$(yq '.modules[-1].sources[2].tag' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
         #"$GITHUB_ENV" <<< "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}"
@@ -76,10 +80,10 @@ jobs:
     - name: Install Freedesktop SDK and DotNet Runtime
       run: |
         flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak update -y
-        flatpak install --user flathub org.flatpak.Builder -y
-        flatpak install --user flathub org.freedesktop.Sdk//${{ env.YQ_RUNTIME_VERSION }} -y
-        flatpak install --user flathub ${{ env.YQ_DOTNETSDK }}//${{ env.YQ_RUNTIME_VERSION }} -y
+        flatpak update --noninteractive -y
+        flatpak install --user flathub org.flatpak.Builder --noninteractive -y
+        flatpak install --user flathub org.freedesktop.Sdk//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
+        flatpak install --user flathub ${{ env.YQ_DOTNETSDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         
     - name: Generate cache for NuGet x64
       run: |

--- a/.github/workflows/NuGet-Checker.yml
+++ b/.github/workflows/NuGet-Checker.yml
@@ -1,8 +1,8 @@
 name: NuGet Checker
 
 on:
-  schedule:
-  - cron: 0 0/12 * * *
+  #schedule:
+  #- cron: 0 0/12 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -1,4 +1,9 @@
-name: NuGet Checker 2024
+# This workflow does 4 things:
+# - Restore data from GitHub Actions cache from previous runs of this workflow.
+# - Regenerate NuGet sources for ARM64 and x86_64 used to build jellyfin. (Previously also confusingly called cache.)
+# - Regenerate Node sources used to build jellyfin-web. (Previously not included in this workflow.)
+# - Create a Pull Request if data has changed.
+name: Regenerate NuGet and Node Sources
 
 on:
   #schedule:
@@ -8,29 +13,31 @@ env:
   MANIFEST: "main/org.jellyfin.JellyfinServer.yml"
 
 jobs:
-  NuGet-Checker:
+  Regenerate-NuGet-Node-Sources:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
 
     steps:
-    - name: Checkout repository
+    - name: Checkout this repository
       uses: actions/checkout@v4
       with:
         path: main
 
-    - name: Check if branch exists
+    - name: Check if branch used for Pull Request exists
       working-directory: main
       run: |
         if [[ -n "$(git ls-remote --heads origin update-nuget)" ]]; then
-          echo "Warning: Branch 'update-nuget' exists. Merge the PR or delete the branch."
+          echo "Warning: Branch 'update-nuget' exists. Merge the Pull Request or delete the branch."
           exit 1
         else
           echo "OK: Branch not found."
         fi
 
-    - name: Restore Flatpak Cache
+    # Restores the path below contains most of the data of installed apps and runtimes.
+    # This can save about 1GB of downloads.
+    - name: Restore Flatpak apps from cache
       uses: actions/cache@v4
       with:
         path: |
@@ -39,23 +46,24 @@ jobs:
         restore-keys: |
           flatpak
 
-    - name: Setup Dependencies Flatpak
+    - name: Install flatpak package
       run: |
         sudo apt-get update -y
         sudo apt-get install flatpak -y --no-install-recommends
 
-    - name: Setup Dependencies yq
+    - name: Install yq binary
       run: |
         mkdir -pv ~/.local/bin
-        wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ~/.local/bin/yq
+        wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+          -O ~/.local/bin/yq
         chmod -v +x ~/.local/bin/yq
 
-    - name: Set ENV Variables
+    - name: Extract environment variables from manifest
       run: |
         # Freedesktop SDK runtime rersion, example: 24.08
         echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
-        # Jellyfin tag, example: 10.10
-        echo "YQ_TAG=$(yq '.modules[-1].sources[2].tag' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        # Jellyfin tag, example: 10.10.3
+        echo "YQ_JF_TAG=$(yq '.modules[-1].sources[2].tag' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
         # DotNet SDK, example: org.freedesktop.Sdk.Extension.dotnet8
         echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
         # DotNet version, example: 8
@@ -64,27 +72,7 @@ jobs:
         # Node SDK, example: org.freedesktop.Sdk.Extension.node22
         echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
 
-    - name: Checkout Jellyfin
-      uses: actions/checkout@v4
-      with:
-        repository: jellyfin/jellyfin
-        path: jellyfin
-        ref: ${{ env.YQ_TAG }}
-
-    - name: Checkout Jellyfin Web
-      uses: actions/checkout@v4
-      with:
-        repository: jellyfin/jellyfin-web
-        path: jellyfin-web
-        ref: ${{ env.YQ_TAG }}
-
-    - name: Checkout Flatpak Builder Tools
-      uses: actions/checkout@v4
-      with:
-        repository: flatpak/flatpak-builder-tools
-        path: flatpak-builder-tools
-
-    - name: Install Freedesktop SDK and DotNet Runtime
+    - name: Install Flatpak Builder, Freedesktop SDK, DotNet and Node
       run: |
         flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         flatpak update --user --noninteractive -y
@@ -92,22 +80,42 @@ jobs:
         flatpak install --user flathub org.freedesktop.Sdk//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         flatpak install --user flathub ${{ env.YQ_DOTNETSDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
         flatpak install --user flathub ${{ env.YQ_NODESDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
-        
-    - name: Generate cache for NuGet x64
+
+    - name: Checkout Flatpak Builder Tools
+      uses: actions/checkout@v4
+      with:
+        repository: flatpak/flatpak-builder-tools
+        path: flatpak-builder-tools
+
+    - name: Checkout jellyfin
+      uses: actions/checkout@v4
+      with:
+        repository: jellyfin/jellyfin
+        path: jellyfin
+        ref: ${{ env.YQ_JF_TAG }}
+
+    - name: Checkout jellyfin-web
+      uses: actions/checkout@v4
+      with:
+        repository: jellyfin/jellyfin-web
+        path: jellyfin-web
+        ref: ${{ env.YQ_JF_TAG }}
+
+    - name: Generate sources for NuGet x64 used by jellyfin
       run: |
         ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py \
-          --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.RUNTIME_VER }} --runtime=linux-x64 \
+          --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.YQ_RUNTIME_VERSION }} --runtime=linux-x64 \
           main/nuget-generated-sources-x64.json \
           jellyfin/Jellyfin.Server/Jellyfin.Server.csproj
 
-    - name: Generate cache for NuGet arm64
+    - name: Generate sources for NuGet arm64 used by jellyfin
       run: |
         ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py \
-          --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.RUNTIME_VER }} --runtime=linux-arm64 \
+          --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.YQ_RUNTIME_VERSION }} --runtime=linux-arm64 \
           main/nuget-generated-sources-arm64.json \
           jellyfin/Jellyfin.Server/Jellyfin.Server.csproj
 
-    - name: Generate cache for Node
+    - name: Generate sources for Node used by jellyfin-web 
       run: |
         ./flatpak-builder-tools/node/flatpak-node-generator \
         -o "main/npm-generated-sources.json" npm "jellyfin-web/package-lock.json"

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -3,9 +3,18 @@
 # - Regenerate NuGet sources for ARM64 and x86_64 used to build jellyfin. (Previously also confusingly called cache.)
 # - Regenerate Node sources used to build jellyfin-web. (Previously not included in this workflow.)
 # - Create a Pull Request if data has changed.
+#
+# NOTE:
+# - Why so many env blocks? https://woodruffw.github.io/zizmor/audits/#template-injection
+#
 name: Regenerate NuGet and Node Sources
-
 on:
+  # Running this workflow on a schedule with the current tooling will only
+  # create noise and waste resources. The order of the dependencies can change
+  # while versions and hashes remain the same. Since this workflow now exists
+  # and is considered complete, a maintainer should be able to run this
+  # workflow on demand from the GitHub app on a mobile device when the bot
+  # detects a new release of Jellyfin.
   #schedule:
   #- cron: 0 0/12 * * *
   workflow_dispatch:
@@ -23,6 +32,7 @@ jobs:
     - name: Checkout this repository
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         path: main
 
     - name: Check if branch used for Pull Request exists
@@ -61,39 +71,48 @@ jobs:
     - name: Extract environment variables from manifest
       run: |
         # Freedesktop SDK runtime rersion, example: 24.08
-        echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${MANIFEST})" >> "$GITHUB_ENV"
         # Jellyfin tag, example: 10.10.3
-        echo "YQ_JF_TAG=$(yq '.modules[-1].sources[2].tag' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        echo "YQ_JF_TAG=$(yq '.modules[-1].sources[2].tag' ${MANIFEST})" >> "$GITHUB_ENV"
         # DotNet SDK, example: org.freedesktop.Sdk.Extension.dotnet8
-        echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${MANIFEST})" >> "$GITHUB_ENV"
         # DotNet version, example: 8
-        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' ${{ env.MANIFEST }})"
+        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' ${MANIFEST})"
         echo "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}" >> "$GITHUB_ENV"
         # Node SDK, example: org.freedesktop.Sdk.Extension.node22
-        echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' ${{ env.MANIFEST }})" >> "$GITHUB_ENV"
+        echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' ${MANIFEST})" >> "$GITHUB_ENV"
+      env:
+        MANIFEST: ${{ env.MANIFEST }}
 
     - name: Install Flatpak Builder, Freedesktop SDK, DotNet and Node
       run: |
         flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         flatpak update --user --noninteractive -y
         flatpak install --user flathub org.flatpak.Builder --noninteractive -y
-        flatpak install --user flathub org.freedesktop.Sdk//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
-        flatpak install --user flathub ${{ env.YQ_DOTNETSDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
-        flatpak install --user flathub ${{ env.YQ_NODESDK }}//${{ env.YQ_RUNTIME_VERSION }} --noninteractive -y
+        flatpak install --user flathub org.freedesktop.Sdk//${YQ_RUNTIME_VERSION} --noninteractive -y
+        flatpak install --user flathub ${YQ_DOTNETSDK}//${YQ_RUNTIME_VERSION} --noninteractive -y
+        flatpak install --user flathub ${YQ_NODESDK}//${YQ_RUNTIME_VERSION} --noninteractive -y
+      env:
+        DOT_NET_VER: ${{ env.DOT_NET_VER }}
+        YQ_DOTNETSDK: ${{ env.YQ_DOTNETSDK }}
+        YQ_NODESDK: ${{ env.YQ_NODESDK }}
+        YQ_RUNTIME_VERSION: ${{ env.YQ_RUNTIME_VERSION }}
 
     - name: Checkout Flatpak Builder Tools
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         repository: flatpak/flatpak-builder-tools
         path: flatpak-builder-tools
 
-    - name: Generate sources for NuGet x64 used by jellyfin
+    - name: Install flatpak-node-generator wit pipx
       run: |
         pipx install "./flatpak-builder-tools/node/"
 
     - name: Checkout jellyfin
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         repository: jellyfin/jellyfin
         path: jellyfin
         ref: ${{ env.YQ_JF_TAG }}
@@ -101,6 +120,7 @@ jobs:
     - name: Checkout jellyfin-web
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         repository: jellyfin/jellyfin-web
         path: jellyfin-web
         ref: ${{ env.YQ_JF_TAG }}
@@ -108,20 +128,25 @@ jobs:
     - name: Generate sources for NuGet x64 used by jellyfin
       run: |
         ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py \
-          --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.YQ_RUNTIME_VERSION }} --runtime=linux-x64 \
-          main/nuget-generated-sources-x64.json \
-          jellyfin/Jellyfin.Server/Jellyfin.Server.csproj
+          --dotnet ${DOT_NET_VER} --freedesktop ${YQ_RUNTIME_VERSION} --runtime=linux-x64 \
+          "main/nuget-generated-sources-x64.json" \
+          "jellyfin/Jellyfin.Server/Jellyfin.Server.csproj"
+      env:
+        DOT_NET_VER: ${{ env.DOT_NET_VER }}
+        YQ_RUNTIME_VERSION: ${{ env.YQ_RUNTIME_VERSION }}
 
     - name: Generate sources for NuGet arm64 used by jellyfin
       run: |
         ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py \
-          --dotnet ${{ env.DOT_NET_VER }} --freedesktop ${{ env.YQ_RUNTIME_VERSION }} --runtime=linux-arm64 \
-          main/nuget-generated-sources-arm64.json \
-          jellyfin/Jellyfin.Server/Jellyfin.Server.csproj
+          --dotnet ${DOT_NET_VER} --freedesktop ${YQ_RUNTIME_VERSION} --runtime=linux-arm64 \
+          "main/nuget-generated-sources-arm64.json" \
+          "jellyfin/Jellyfin.Server/Jellyfin.Server.csproj"
+      env:
+        DOT_NET_VER: ${{ env.DOT_NET_VER }}
+        YQ_RUNTIME_VERSION: ${{ env.YQ_RUNTIME_VERSION }}
 
     - name: Generate sources for Node used by jellyfin-web 
       run: |
-        #./flatpak-builder-tools/node/flatpak-node-generator \
         flatpak-node-generator \
         -o "main/npm-generated-sources.json" npm "jellyfin-web/package-lock.json"
 

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -46,10 +46,10 @@ jobs:
         restore-keys: |
           flatpak
 
-    - name: Install flatpak package
+    - name: Install flatpak and pipx package
       run: |
         sudo apt-get update -y
-        sudo apt-get install flatpak -y --no-install-recommends
+        sudo apt-get install flatpak pipx -y --no-install-recommends
 
     - name: Install yq binary
       run: |
@@ -87,6 +87,10 @@ jobs:
         repository: flatpak/flatpak-builder-tools
         path: flatpak-builder-tools
 
+    - name: Generate sources for NuGet x64 used by jellyfin
+      run: |
+        pipx install "./flatpak-builder-tools/node/"
+
     - name: Checkout jellyfin
       uses: actions/checkout@v4
       with:
@@ -117,7 +121,8 @@ jobs:
 
     - name: Generate sources for Node used by jellyfin-web 
       run: |
-        ./flatpak-builder-tools/node/flatpak-node-generator \
+        #./flatpak-builder-tools/node/flatpak-node-generator \
+        flatpak-node-generator \
         -o "main/npm-generated-sources.json" npm "jellyfin-web/package-lock.json"
 
     - name: Create Pull Request


### PR DESCRIPTION
- Remove warnings about apt/apt-get, apt `--no-install-recommends` reduces size by half, silence wget, use `--user` with flatpak to avoid sudo, silence flatpak with `--noninteractive`
- Improve description of steps
- Check quality/security with zizmor
- Disable scheduled runs of NuGet-Checker.yml \
  Replaced by regenerate-sources.yml, see comments in there why scheduled runs are not useful.