### PR TITLE
Resolve action-lint and zizmor findings, check upstream tags

### DIFF
--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,0 +1,1 @@
+pre-commit

--- a/.github/workflows/NuGet-Checker.yml
+++ b/.github/workflows/NuGet-Checker.yml
@@ -1,4 +1,4 @@
-name: NuGet Checker
+name: NuGet Checker (obsolete)
 
 on:
   #schedule:

--- a/.github/workflows/ga-updater.yml
+++ b/.github/workflows/ga-updater.yml
@@ -4,8 +4,8 @@ on:
   # vsoch/action-updater@0.0.16 is not allowed to be used in flathub/org.jellyfin.JellyfinServer.
   # Actions in this workflow must be: within a repository owned by flathub, created by GitHub, or matching the following:
   # docker/*, docker://ghcr.io/flathub/*, flathub/*, peter-evans/create-pull-request@*.
-  schedule:
-  - cron: 15 9 * * SAT
+  #schedule:
+  #- cron: 15 9 * * SAT
   workflow_dispatch:
 #env:
 #  PR_BRANCH: update-ga

--- a/.github/workflows/ga-updater.yml
+++ b/.github/workflows/ga-updater.yml
@@ -1,0 +1,48 @@
+name: Update GitHub Actions Workflows
+on:
+  schedule:
+  - cron: 15 9 * * SAT
+  workflow_dispatch:
+env:
+  PR_BRANCH: update-ga
+
+jobs:
+  ga-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        path: main
+
+    # TODO: Is there a better way to handle this?
+    - name: Check if branch used for Pull Request exists
+      working-directory: main
+      run: |
+        if [[ -n "$(git ls-remote --heads origin ${PR_BRANCH})" ]]; then
+          echo "Warning: Branch '${PR_BRANCH}' exists. Merge the Pull Request or delete the branch."
+          exit 1
+        else
+          echo "OK: Branch not found."
+        fi
+      env:
+        PR_BRANCH: ${{ env.PR_BRANCH }}
+
+    - name: action-updater
+      uses: vsoch/action-updater@0.0.16
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+      with:
+        path: main
+        title: Update GitHub Actions Workflows
+        commit-message: Update GitHub Actions Workflows
+        branch: ${{ env.PR_BRANCH }}
+        delete-branch: true
+      #env:
+      #  PR_BRANCH: ${{ env.PR_BRANCH }}

--- a/.github/workflows/ga-updater.yml
+++ b/.github/workflows/ga-updater.yml
@@ -1,48 +1,64 @@
 name: Update GitHub Actions Workflows
 on:
+  # NOTE:
+  # vsoch/action-updater@0.0.16 is not allowed to be used in flathub/org.jellyfin.JellyfinServer.
+  # Actions in this workflow must be: within a repository owned by flathub, created by GitHub, or matching the following:
+  # docker/*, docker://ghcr.io/flathub/*, flathub/*, peter-evans/create-pull-request@*.
   schedule:
   - cron: 15 9 * * SAT
   workflow_dispatch:
-env:
-  PR_BRANCH: update-ga
+#env:
+#  PR_BRANCH: update-ga
 
 jobs:
   ga-update:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+#    permissions:
+#      contents: write
+#      pull-requests: write
+#      #actions: write
 
     steps:
     - name: Checkout this repository
       uses: actions/checkout@v4
       with:
         persist-credentials: false
-        path: main
 
-    # TODO: Is there a better way to handle this?
-    - name: Check if branch used for Pull Request exists
-      working-directory: main
+#    # TODO: Is there a better way to handle this?
+#    - name: Check if branch used for Pull Request exists
+#      working-directory: main
+#      run: |
+#        if [[ -n "$(git ls-remote --heads origin "${PR_BRANCH}")" ]]; then
+#          echo "Warning: Branch '${PR_BRANCH}' exists. Merge the Pull Request or delete the branch."
+#          exit 1
+#        else
+#          echo "OK: Branch not found."
+#        fi
+#      env:
+#        PR_BRANCH: ${{ env.PR_BRANCH }}
+
+#    # This only checks for updates, despite of what the documentation says
+#    - name: Check for updates
+#      uses: vsoch/action-updater@0.0.16
+
+    - name: Install pipx package
       run: |
-        if [[ -n "$(git ls-remote --heads origin ${PR_BRANCH})" ]]; then
-          echo "Warning: Branch '${PR_BRANCH}' exists. Merge the Pull Request or delete the branch."
-          exit 1
-        else
-          echo "OK: Branch not found."
-        fi
-      env:
-        PR_BRANCH: ${{ env.PR_BRANCH }}
+        sudo apt-get update -y
+        sudo apt-get install pipx -y --no-install-recommends
 
-    - name: action-updater
-      uses: vsoch/action-updater@0.0.16
+    - name: Install action-updater wit pipx
+      run: |
+        pipx install action-updater
 
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
-      with:
-        path: main
-        title: Update GitHub Actions Workflows
-        commit-message: Update GitHub Actions Workflows
-        branch: ${{ env.PR_BRANCH }}
-        delete-branch: true
-      #env:
-      #  PR_BRANCH: ${{ env.PR_BRANCH }}
+    - name: Check for updates
+      run: |
+        action-updater detect .github/workflows/
+        #action-updater update .github/workflows/
+
+#    - name: Create Pull Request
+#      uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+#      with:
+#        title: Update GitHub Actions Workflows
+#        commit-message: Update GitHub Actions Workflows
+#        branch: ${{ env.PR_BRANCH }}
+#        delete-branch: true

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -9,18 +9,23 @@
 #
 name: Regenerate NuGet and Node Sources
 on:
+  # TODO: Remove, seems to be fixed.
   # Running this workflow on a schedule with the current tooling will only
   # create noise and waste resources. The order of the dependencies can change
   # while versions and hashes remain the same. Since this workflow now exists
   # and is considered complete, a maintainer should be able to run this
   # workflow on demand from the GitHub app on a mobile device when the bot
   # detects a new release of Jellyfin.
-  #schedule:
-  #- cron: 0 0/12 * * *
+  schedule:
+  # Past releases usually happened late on Ssturday
+  - cron: 15 6 * * SUN
   workflow_dispatch:
 env:
   MANIFEST: "main/org.jellyfin.JellyfinServer.yml"
   PR_BRANCH: update-nuget-node
+  REPO_BACKEND: "jellyfin/jellyfin"
+  REPO_FRONTEND: "jellyfin/jellyfin-web"
+  SOFTWARE_NAME: "Jellyfin"
 
 jobs:
   Regenerate-NuGet-Node-Sources:
@@ -64,13 +69,36 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install flatpak pipx -y --no-install-recommends
 
-    # NOTE: Seems to be already on the latest runner.
-    #- name: Install yq binary
-    #  run: |
-    #    mkdir -pv ~/.local/bin
-    #    wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-    #      -O ~/.local/bin/yq
-    #    chmod -v +x ~/.local/bin/yq
+    - name: Install yq binary, if necessary
+      run: |
+        if ! command -v "yq" > /dev/null 2>&1; then
+          mkdir -pv ~/.local/bin
+          wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -O ~/.local/bin/yq
+          chmod -v +x ~/.local/bin/yq
+        fi
+
+    - name: Get latest ${{ env.SOFTWARE_NAME }} frontend tag
+      id: jq_tag_jf_fe
+      run: |
+        latest_tag=$(
+          curl -s "https://api.github.com/repos/${REPO_FRONTEND}/releases/latest" \
+            | jq -r '.tag_name'
+        )
+        echo "JQ_TAG_JF_FE=$latest_tag" >> "$GITHUB_OUTPUT"
+      env:
+        REPO_FRONTEND: ${{ env.REPO_FRONTEND }}
+
+    - name: Get latest ${{ env.SOFTWARE_NAME }} backend tag
+      id: jq_tag_jf_be
+      run: |
+        latest_tag=$(
+          curl -s "https://api.github.com/repos/${REPO_BACKEND}/releases/latest" \
+            | jq -r '.tag_name'
+        )
+        echo "JQ_TAG_JF_BE=$latest_tag" >> "$GITHUB_OUTPUT"
+      env:
+        REPO_BACKEND: ${{ env.REPO_BACKEND }}
 
     - name: Extract environment variables from manifest
       run: |
@@ -86,7 +114,20 @@ jobs:
         echo "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}" >> "$GITHUB_ENV"
         # Node SDK, example: org.freedesktop.Sdk.Extension.node22
         echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' "${MANIFEST}")" >> "$GITHUB_ENV"
+        # If frontend and backend tags are equal, and backend tag is not empty,
+        # and backend tag does not match the manifest, then there must be a new
+        # release.
+        # shellcheck disable=SC2153
+        if [[ "${JQ_TAG_JF_FE}" == "${JQ_TAG_JF_BE}" && -n "${JQ_TAG_JF_BE}" && "${JQ_TAG_JF_BE}" != "${YQ_JF_TAG}" ]]; then
+          echo "JF_TAG=${JQ_TAG_JF_BE}" >> "$GITHUB_ENV"
+          echo "NEW_RELEASE_DETECTED=true" >> "$GITHUB_ENV"
+        else
+          echo "JF_TAG=${YQ_JF_TAG}" >> "$GITHUB_ENV"
+          echo "NEW_RELEASE_DETECTED=false" >> "$GITHUB_ENV"
+        fi
       env:
+        JQ_TAG_JF_FE: ${{ env.JQ_TAG_JF_FE }}
+        JQ_TAG_JF_BE: ${{ env.JQ_TAG_JF_BE }}
         MANIFEST: ${{ env.MANIFEST }}
 
     - name: Install Flatpak Builder, Freedesktop SDK, DotNet and Node
@@ -120,7 +161,7 @@ jobs:
         persist-credentials: false
         repository: jellyfin/jellyfin
         path: jellyfin
-        ref: ${{ env.YQ_JF_TAG }}
+        ref: ${{ env.JF_TAG }}
 
     - name: Checkout jellyfin-web
       uses: actions/checkout@v4
@@ -128,7 +169,7 @@ jobs:
         persist-credentials: false
         repository: jellyfin/jellyfin-web
         path: jellyfin-web
-        ref: ${{ env.YQ_JF_TAG }}
+        ref: ${{ env.JF_TAG }}
 
     - name: Generate sources for NuGet x64 used by jellyfin
       run: |
@@ -171,7 +212,7 @@ jobs:
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:
         path: main
-        title: Regenerate NuGet and Node Sources
-        commit-message: Regenerate NuGet and Node Sources
+        title: Regenerate NuGet and Node Sources ${{ env.JF_TAG }}
+        commit-message: Regenerate NuGet and Node Sources ${{ env.JF_TAG }}
         branch: ${{ env.PR_BRANCH }}
         delete-branch: true

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -20,6 +20,7 @@ on:
   workflow_dispatch:
 env:
   MANIFEST: "main/org.jellyfin.JellyfinServer.yml"
+  PR_BRANCH: update-nuget-node
 
 jobs:
   Regenerate-NuGet-Node-Sources:
@@ -38,12 +39,14 @@ jobs:
     - name: Check if branch used for Pull Request exists
       working-directory: main
       run: |
-        if [[ -n "$(git ls-remote --heads origin update-nuget)" ]]; then
-          echo "Warning: Branch 'update-nuget' exists. Merge the Pull Request or delete the branch."
+        if [[ -n "$(git ls-remote --heads origin ${PR_BRANCH})" ]]; then
+          echo "Warning: Branch '${PR_BRANCH}' exists. Merge the Pull Request or delete the branch."
           exit 1
         else
           echo "OK: Branch not found."
         fi
+      env:
+        PR_BRANCH: ${{ env.PR_BRANCH }}
 
     # Restores the path below contains most of the data of installed apps and runtimes.
     # This can save about 1GB of downloads.
@@ -145,7 +148,7 @@ jobs:
         DOT_NET_VER: ${{ env.DOT_NET_VER }}
         YQ_RUNTIME_VERSION: ${{ env.YQ_RUNTIME_VERSION }}
 
-    - name: Generate sources for Node used by jellyfin-web 
+    - name: Generate sources for Node used by jellyfin-web
       run: |
         flatpak-node-generator \
         -o "main/npm-generated-sources.json" npm "jellyfin-web/package-lock.json"
@@ -154,7 +157,7 @@ jobs:
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:
         path: main
-        title: Update NuGet Cache
-        commit-message: Update NuGet Cache
-        branch: update-nuget
+        title: Regenerate NuGet and Node Sources
+        commit-message: Regenerate NuGet and Node Sources
+        branch: ${{ env.PR_BRANCH }}
         delete-branch: true

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Check if branch used for Pull Request exists
       working-directory: main
       run: |
-        if [[ -n "$(git ls-remote --heads origin ${PR_BRANCH})" ]]; then
+        if [[ -n "$(git ls-remote --heads origin "${PR_BRANCH}")" ]]; then
           echo "Warning: Branch '${PR_BRANCH}' exists. Merge the Pull Request or delete the branch."
           exit 1
         else

--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -64,26 +64,28 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install flatpak pipx -y --no-install-recommends
 
-    - name: Install yq binary
-      run: |
-        mkdir -pv ~/.local/bin
-        wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-          -O ~/.local/bin/yq
-        chmod -v +x ~/.local/bin/yq
+    # NOTE: Seems to be already on the latest runner.
+    #- name: Install yq binary
+    #  run: |
+    #    mkdir -pv ~/.local/bin
+    #    wget --quiet https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+    #      -O ~/.local/bin/yq
+    #    chmod -v +x ~/.local/bin/yq
 
     - name: Extract environment variables from manifest
       run: |
+        # shellcheck disable=SC2129
         # Freedesktop SDK runtime rersion, example: 24.08
-        echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' ${MANIFEST})" >> "$GITHUB_ENV"
+        echo "YQ_RUNTIME_VERSION=$(yq '.runtime-version' "${MANIFEST}")" >> "$GITHUB_ENV"
         # Jellyfin tag, example: 10.10.3
-        echo "YQ_JF_TAG=$(yq '.modules[-1].sources[2].tag' ${MANIFEST})" >> "$GITHUB_ENV"
+        echo "YQ_JF_TAG=$(yq '.modules[-1].sources[2].tag' "${MANIFEST}")" >> "$GITHUB_ENV"
         # DotNet SDK, example: org.freedesktop.Sdk.Extension.dotnet8
-        echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' ${MANIFEST})" >> "$GITHUB_ENV"
+        echo "YQ_DOTNETSDK=$(yq '.sdk-extensions[0]' "${MANIFEST}")" >> "$GITHUB_ENV"
         # DotNet version, example: 8
-        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' ${MANIFEST})"
+        YQ_DOTNETSDK="$(yq '.sdk-extensions[0]' "${MANIFEST}")"
         echo "DOT_NET_VER=${YQ_DOTNETSDK##*dotnet}" >> "$GITHUB_ENV"
         # Node SDK, example: org.freedesktop.Sdk.Extension.node22
-        echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' ${MANIFEST})" >> "$GITHUB_ENV"
+        echo "YQ_NODESDK=$(yq '.sdk-extensions[1]' "${MANIFEST}")" >> "$GITHUB_ENV"
       env:
         MANIFEST: ${{ env.MANIFEST }}
 
@@ -91,10 +93,10 @@ jobs:
       run: |
         flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         flatpak update --user --noninteractive -y
-        flatpak install --user flathub org.flatpak.Builder --noninteractive -y
-        flatpak install --user flathub org.freedesktop.Sdk//${YQ_RUNTIME_VERSION} --noninteractive -y
-        flatpak install --user flathub ${YQ_DOTNETSDK}//${YQ_RUNTIME_VERSION} --noninteractive -y
-        flatpak install --user flathub ${YQ_NODESDK}//${YQ_RUNTIME_VERSION} --noninteractive -y
+        flatpak install --user flathub "org.flatpak.Builder" --noninteractive -y
+        flatpak install --user flathub "org.freedesktop.Sdk//${YQ_RUNTIME_VERSION}" --noninteractive -y
+        flatpak install --user flathub "${YQ_DOTNETSDK}//${YQ_RUNTIME_VERSION}" --noninteractive -y
+        flatpak install --user flathub "${YQ_NODESDK}//${YQ_RUNTIME_VERSION}" --noninteractive -y
       env:
         DOT_NET_VER: ${{ env.DOT_NET_VER }}
         YQ_DOTNETSDK: ${{ env.YQ_DOTNETSDK }}
@@ -108,7 +110,7 @@ jobs:
         repository: flatpak/flatpak-builder-tools
         path: flatpak-builder-tools
 
-    - name: Install flatpak-node-generator wit pipx
+    - name: Install flatpak-node-generator with pipx
       run: |
         pipx install "./flatpak-builder-tools/node/"
 
@@ -131,7 +133,7 @@ jobs:
     - name: Generate sources for NuGet x64 used by jellyfin
       run: |
         ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py \
-          --dotnet ${DOT_NET_VER} --freedesktop ${YQ_RUNTIME_VERSION} --runtime=linux-x64 \
+          --dotnet "${DOT_NET_VER}" --freedesktop "${YQ_RUNTIME_VERSION}" --runtime=linux-x64 \
           "main/nuget-generated-sources-x64.json" \
           "jellyfin/Jellyfin.Server/Jellyfin.Server.csproj"
       env:
@@ -141,7 +143,7 @@ jobs:
     - name: Generate sources for NuGet arm64 used by jellyfin
       run: |
         ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py \
-          --dotnet ${DOT_NET_VER} --freedesktop ${YQ_RUNTIME_VERSION} --runtime=linux-arm64 \
+          --dotnet "${DOT_NET_VER}" --freedesktop "${YQ_RUNTIME_VERSION}" --runtime=linux-arm64 \
           "main/nuget-generated-sources-arm64.json" \
           "jellyfin/Jellyfin.Server/Jellyfin.Server.csproj"
       env:
@@ -152,6 +154,18 @@ jobs:
       run: |
         flatpak-node-generator \
         -o "main/npm-generated-sources.json" npm "jellyfin-web/package-lock.json"
+
+    - name: Install Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: latest
+
+    - name: Install Prettier
+      run: |
+        npm install -g prettier
+
+    - name: Reformat JSON files
+      run: npx prettier --write "main/"*".json"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,23 @@ jellyfin/
 repo/
 VERSION
 checksums.txt
+
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,8 @@ repos:
     hooks:
     - id: zizmor
       files: ^\.github/workflows/.*\.ya?ml$
+  # NOTE: It looks like community maintainers have given up on maintaining the
+  # prettier pre-commit hook. Therefore we integrate it in the makefile.
   # This takes a few seconds longer, but it is so wasteful and embarrassing when a builder fails with a linter error.
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,11 @@ repos:
     hooks:
       - id: gitleaks
         args: ["--no-banner"]
+  - repo: https://github.com/woodruffw/zizmor
+    rev: v0.5.0
+    hooks:
+    - id: zizmor
+      files: ^\.github/workflows/.*\.yml$
   # This takes a few seconds longer, but it is so wasteful and embarrassing when a builder fails with a linter error.
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,11 +55,15 @@ repos:
     hooks:
       - id: gitleaks
         args: ["--no-banner"]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.27
+    hooks:
+      - id: actionlint
   - repo: https://github.com/woodruffw/zizmor
     rev: v0.5.0
     hooks:
     - id: zizmor
-      files: ^\.github/workflows/.*\.yml$
+      files: ^\.github/workflows/.*\.ya?ml$
   # This takes a few seconds longer, but it is so wasteful and embarrassing when a builder fails with a linter error.
   - repo: local
     hooks:

--- a/nuget-generated-sources-arm64.json
+++ b/nuget-generated-sources-arm64.json
@@ -1,1773 +1,1773 @@
 [
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/asynckeyedlock/7.0.2/asynckeyedlock.7.0.2.nupkg",
-        "sha512": "3531c49506ca4166791bc4a394d00690c35c52a5ffa1f0946bc02cf9ead793f82f933a6c90ec85ddd67e97723ca56da998cf3a586cbb75db1fe39bbe64b479c7",
-        "dest": "nuget-sources",
-        "dest-filename": "asynckeyedlock.7.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/bdinfo/0.8.0/bdinfo.0.8.0.nupkg",
-        "sha512": "b9b3e42e71def59d5150ad4a830f8792b39bfd1964a5c975e509fcd47569cbaaae763da098346f852f90dcd5c82bf9136d3130819d12c1452b2b9f21cad14367",
-        "dest": "nuget-sources",
-        "dest-filename": "bdinfo.0.8.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp/1.3.3/blurhashsharp.1.3.3.nupkg",
-        "sha512": "7a49ff313da159a1aefc91279c77eb7265a52c50118e4b91d2174a225edfaec13051cc49023fdc4c08ce52635bd68d88e1de9c5968d885fc0d5e53934ea96c17",
-        "dest": "nuget-sources",
-        "dest-filename": "blurhashsharp.1.3.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp.skiasharp/1.3.3/blurhashsharp.skiasharp.1.3.3.nupkg",
-        "sha512": "f17106411b69a58580e0854a662d44623445e96866d6cf8834865ff978dd1f08ab5646632f35799ed53f56d13d5624efa0e44f60bf10b116c0459c41bc9b2fad",
-        "dest": "nuget-sources",
-        "dest-filename": "blurhashsharp.skiasharp.1.3.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.9.1/commandlineparser.2.9.1.nupkg",
-        "sha512": "4f364e45c9668c7e7cc6a922b488f3fa523033c20d7a432694f0a6af05ce528ea0481d8375e2f4f1032c6990347b4803ce9a0e48068c6fe15ec46fb1254f085d",
-        "dest": "nuget-sources",
-        "dest-filename": "commandlineparser.2.9.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/diacritics/3.3.29/diacritics.3.3.29.nupkg",
-        "sha512": "48d53debccd23a0cea558199f19e26313db0d56f5e65cd9b5866b2c4bc9ccd2273088be9528eba504b43aefdcbc44f2fa54ae175e2c8e5fcbec04fef92be5382",
-        "dest": "nuget-sources",
-        "dest-filename": "diacritics.3.3.29.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.core/0.16.13/discutils.core.0.16.13.nupkg",
-        "sha512": "637e7448e43b8f022858b88073b9a10a937af6878846734ca19eee56af7d0f66a09aec007948eb50b16fc09c78b5526c38773487e956d906566d66459551c47b",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.core.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.iso9660/0.16.13/discutils.iso9660.0.16.13.nupkg",
-        "sha512": "6c9e2c62e2e25c119da650d5991375618f61d7935856a19ddef1f5626ccdff7ada3b32443e03272cf1ee68f384d29759d677dc182f8b9377bc7fddbbc4778998",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.iso9660.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.streams/0.16.13/discutils.streams.0.16.13.nupkg",
-        "sha512": "81fe953b957867ebd9922c55713d1700ee9857345df63c565ab8ba8a3253929fc111fcf477494b6a713f615465aa62f55b17f4f651baae20e59296fe4af27696",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.streams.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.udf/0.16.13/discutils.udf.0.16.13.nupkg",
-        "sha512": "cf8a49baae53e46515eabb53250e2d8d12956cffc61ce38c25abeafcde84b39b1d8e87b4ae9bcbb6293ac46e06743148bb312ed0f2ac649f1ce6c32c20fcfeb6",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.udf.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/dotnet.glob/3.1.3/dotnet.glob.3.1.3.nupkg",
-        "sha512": "9a3ffb310bf2a3383d869a6347c3578cc7c02318caeefcef73c4343d3b15592054f483840ea0d024e537edde6c63630ad5a90c5d8d3a41ef67f8033003dc3a92",
-        "dest": "nuget-sources",
-        "dest-filename": "dotnet.glob.3.1.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/excss/4.2.3/excss.4.2.3.nupkg",
-        "sha512": "fcb06d04937a6bd864060e8bdf4a65970c7450cdbdd3279465851310ac8bf12b645cac54ce8b7a8039c7ca9309ba3d9ee4e23827599479c4140f7755e119caa9",
-        "dest": "nuget-sources",
-        "dest-filename": "excss.4.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.3/harfbuzzsharp.7.3.0.3.nupkg",
-        "sha512": "bed625c58228c404f860fb3e247fb6ca3209c93fea62da498ba43419500bd40944b2e117f50f587f860101a6c6478ad1d18075f655376d1749d238d74b6a0bd3",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.3/harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg",
-        "sha512": "cf94e5693c4c475a702c342163f1ee28d2d9c3a13939a8334bb7133d13ffc5ed95d9dbb6145e7ac004cfd6e626a16280df7f1a4c7e3687569eced58b8890a1b5",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.3/harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg",
-        "sha512": "a6dac2eb2c536f25734e5358aaae9263f568871fa31169e816d8617c5b6e933d78e2956ea9e01ac37e0022bf243e63124956804b46f6a0d00826aa02320ef22b",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.3/harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg",
-        "sha512": "dd940d3b3085996b4e5961a0e42bb1a86daad360e3377602fafd60b0cb4d3d5ed9c3f4293a8551df75f38111b3a9f4dbbea4cb27b3e0632a6d48239b606d13c9",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.14.1/humanizer.core.2.14.1.nupkg",
-        "sha512": "cb3a8653f1ca34b67d52fafa92f49cdf0615fd2e4efc8be4948516e5617b32e8af18b63cc12e486672cf92dec3d4a5bc12dd849e5d08dcbce0daf196336e17b3",
-        "dest": "nuget-sources",
-        "dest-filename": "humanizer.core.2.14.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/icu4n/60.1.0-alpha.356/icu4n.60.1.0-alpha.356.nupkg",
-        "sha512": "f043fff5f139070ff84d2ec0397c2fb571ced6fcf37e2161f68406e9df03b86daa12fbe12a977f6e9f6f1a9bf46de5792d83fd82e4a2c395b3201aa2a846bc90",
-        "dest": "nuget-sources",
-        "dest-filename": "icu4n.60.1.0-alpha.356.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/icu4n.transliterator/60.1.0-alpha.356/icu4n.transliterator.60.1.0-alpha.356.nupkg",
-        "sha512": "1d6552fb8125793b391626ac930075b0db7903041e79bb43394cb75d767ff9c749c83099d73136366773a802ccf4b7537aff21e7c4b7f668e272511f7107af5c",
-        "dest": "nuget-sources",
-        "dest-filename": "icu4n.transliterator.60.1.0-alpha.356.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/idisposableanalyzers/4.0.8/idisposableanalyzers.4.0.8.nupkg",
-        "sha512": "86f93bc4c501c14cd4b0668bebacc54ec380a75ee12a3d973b4634acd230b6cde26743c617533a613005890d2d1a7271cec03ca167337376537dac63f755f07f",
-        "dest": "nuget-sources",
-        "dest-filename": "idisposableanalyzers.4.0.8.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/j2n/2.0.0/j2n.2.0.0.nupkg",
-        "sha512": "7b1fd8117c9608ec5a8502eb604760aaa81b3e490725b0d3fd055f2523053f2e6b9ddf15fb1101dff091949fe92da17a1130a2d295e328ee1a7a3e41a40833c4",
-        "dest": "nuget-sources",
-        "dest-filename": "j2n.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/jellyfin.xmltv/10.8.0/jellyfin.xmltv.10.8.0.nupkg",
-        "sha512": "b1ef253f878f7abb158268b78f29df7240998c63f4f1a94d60486c408abd8ec976b3572a1a0c1c1a149cb7ff4c6a048fc1ae9102c51b556aeddd7bed2e19e1d9",
-        "dest": "nuget-sources",
-        "dest-filename": "jellyfin.xmltv.10.8.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/libse/4.0.8/libse.4.0.8.nupkg",
-        "sha512": "2eb6eb3ae07d746fe8d19c9ae13d086e5f02483024a1accb5ad0e5162d894ff4cc24d430b42bffd75873a7eebe884bb6aa7ab351c4d1e77fea00e3840df9d352",
-        "dest": "nuget-sources",
-        "dest-filename": "libse.4.0.8.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/lrcparser/2024.728.2/lrcparser.2024.728.2.nupkg",
-        "sha512": "d1b27a7e33788e6b29f39a374962eb0ad9276524333cc526528bd53ffd35f14a95071667f6721925a12788b85c1bc458246f2ca76470af2bcd1811a0e4dc0c34",
-        "dest": "nuget-sources",
-        "dest-filename": "lrcparser.2024.728.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common/3.0.0/metabrainz.common.3.0.0.nupkg",
-        "sha512": "01350da82a7dc0ada18e726e15dff30e499491c0807a3fcb4cea5247c38a3c24d0afa34751e12b605cbd86143372e86e2f5b997cb08d1f42bb6dbfbcf67ddea3",
-        "dest": "nuget-sources",
-        "dest-filename": "metabrainz.common.3.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common.json/6.0.2/metabrainz.common.json.6.0.2.nupkg",
-        "sha512": "fa333a0227d1afe406960695b3c8ff8492112dd3a5e58027db63f84dfbd7122756e74af821f506c5137c08e3fa9c363177c3246375ce85acf358d35f961feb94",
-        "dest": "nuget-sources",
-        "dest-filename": "metabrainz.common.json.6.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.musicbrainz/6.1.0/metabrainz.musicbrainz.6.1.0.nupkg",
-        "sha512": "b36824dcbe668234e0974464122140717586b6d4ad881bc3e90d3bddca624f7982de3684e65f1571dd6cd3632e3c7edf6ac9de82a9c82b33a95df223541982e3",
-        "dest": "nuget-sources",
-        "dest-filename": "metabrainz.musicbrainz.6.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/8.0.11/microsoft.aspnetcore.app.runtime.linux-arm64.8.0.11.nupkg",
-        "sha512": "cfa9709633e91184bdd061951bf480e66da86175384e3a35ccc9ebbc768f207785807bc48628fd4101ecf6336a9495fbc9cb02aea3c0b9543c02e73fb96fb4f8",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.authorization/8.0.11/microsoft.aspnetcore.authorization.8.0.11.nupkg",
-        "sha512": "4f310a03a421ba8100430881ed34fedb75b10e3c6845bcf97cddc6927884e341778399b3bdee4c4fc1b4e5ea91a5f4cbe70da746d7f4efae092a71d41b97dd52",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.authorization.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.metadata/8.0.11/microsoft.aspnetcore.metadata.8.0.11.nupkg",
-        "sha512": "d37a9d96f337e62d71c82ea63685553011039d2e940ca2b4f5690a15cabd4e0e84e1c66a59a5b429dfb221efc577937b6421b672a9e4e6ffdc69ea4bef0f9b61",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.metadata.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/6.0.0/microsoft.bcl.asyncinterfaces.6.0.0.nupkg",
-        "sha512": "221a05a0c910f7a87b620d8f3831ed392b4eb95d112bee274d35f27009ad2a26445de9d7cd235fe6fb4a03f2550874bda3be3dddd96edaf9c0852a9c23d7b099",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.3/microsoft.codeanalysis.analyzers.3.3.3.nupkg",
-        "sha512": "0d4896db8aff9d731c5b1c8f73a4b37460c3f08080fbeac0ecf169abf5bdff9c9a994778f453816b888e939d9d0d615245c91a2e4ba31f85d2ea8de222767104",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.analyzers.3.3.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.bannedapianalyzers/3.3.4/microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg",
-        "sha512": "0b8e5e7aa98142864edd0073512f11c899f9b5aad535012726477cc1189de63252895a829c7ffc5730d09e5df8a6db7ccd9d0c6a17007bc94ca0ca5a36e04042",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/4.5.0/microsoft.codeanalysis.common.4.5.0.nupkg",
-        "sha512": "61f1aa2061217670fab3e1043e5068b72aed43907866195c693211407e2b3ebd6cd9762ed0b3e9ef06965a33d3ce3fb09c88f3c900ad32feb0485922575a41e3",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/4.5.0/microsoft.codeanalysis.csharp.4.5.0.nupkg",
-        "sha512": "68d7df26baf9362ec2cabb3543d1f7a570b0f345053a23e8feeb5317c50ba392825bafb1710ebee5c929e762e749782fd11eaadb3b437224ebfccba08b985fcf",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.workspaces/4.5.0/microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg",
-        "sha512": "474703fc47639e146aca623e2c15734c173167789e28bc2e46f65b8691d86c6db4e94723c469e2cea3ebd1f8395f816ad119350b91a88e95b6706db6ff977148",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.workspaces.common/4.5.0/microsoft.codeanalysis.workspaces.common.4.5.0.nupkg",
-        "sha512": "66f89952c90fac37702c0df2d04fbe8561768578baa0aa30a947220b253c952e109f4bb79c852bd471c16ad3957593db6a6e5e468994472f6210d742e6a4757f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.workspaces.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite/8.0.11/microsoft.data.sqlite.8.0.11.nupkg",
-        "sha512": "57374540586b0da9b6ae53ae4bea10faa84cc33850653366b4fd115783cadc8e4e999e8df9c54976a47a787dac6d71a44f527ed879a2182539ad80b64b445091",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.data.sqlite.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite.core/8.0.11/microsoft.data.sqlite.core.8.0.11.nupkg",
-        "sha512": "81efb4b0feaa97d67502645a4385d8c6a11e3b4e2bb1db3f2211ce2a7e9c703fd9f342126cdd328ff12dcf08be1cbd1478cc134bdf19da5237efc6dff46ab83d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.data.sqlite.core.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore/8.0.11/microsoft.entityframeworkcore.8.0.11.nupkg",
-        "sha512": "cf5d52c7f5d689cace47117d72ff5fef566fd8390006af8001df649bee0a3196ec381b00880db9b83926c5b8a559f7fd397dcb5db15c19e37b7a11bd04b91cd9",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.abstractions/8.0.11/microsoft.entityframeworkcore.abstractions.8.0.11.nupkg",
-        "sha512": "64080c34faacc6cd5831101c8b2245a58c3403ac0b1b5f6b4319ef3f5213673c606cedf541230c599714c49d19e88aba36bdbd4f6281e4db84d4f2c532d6afb7",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.abstractions.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.analyzers/8.0.11/microsoft.entityframeworkcore.analyzers.8.0.11.nupkg",
-        "sha512": "dfb27bfc753587d6f7c6c518bfc3743ed2ee1e35c048a9e0d2512b916f7f3ccc616248760bc780d7217097e3ee076048c24bb2e488b7722576438adff776a83f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.analyzers.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.design/8.0.11/microsoft.entityframeworkcore.design.8.0.11.nupkg",
-        "sha512": "2599c8a3081e8936ebdcea6f090c3611deadbbac48da95f84d922a9fd329d5399337752b2a1381240339f1656e43c4032619b70866dc58a2fbf835c2c2e9e255",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.design.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.relational/8.0.11/microsoft.entityframeworkcore.relational.8.0.11.nupkg",
-        "sha512": "6bf9071342ba151e8da4a28e9cbca2f4a15391c6d4d8e35e281224dfa7baa5b31bb5af34099d37ed3de92dec2aa98b8c80226b852a0fc794bc482ce106c70b1c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.relational.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite/8.0.11/microsoft.entityframeworkcore.sqlite.8.0.11.nupkg",
-        "sha512": "bd6cf8b7574693c262f9fa2c7cfdd59e4cf30999fb5bf6477151934a19dbfb21f94ecb8c9f1b1b9d1a3d3f6e70b541855d37f8c277ff30357edeedaef2dbfb18",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.sqlite.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite.core/8.0.11/microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg",
-        "sha512": "798a06456c660e67bc1e3a2c1049249fe2ce70d3317615ca353562220f7e7e8bff0db2e36b0f392e1e931765084dcd9229c6954c053a04f6b87ae9f2d1f88c75",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.tools/8.0.11/microsoft.entityframeworkcore.tools.8.0.11.nupkg",
-        "sha512": "1ad3b75bed1d444b631b344c9f0bc186d14863ecf8988233e52b53cc7e825e58fd61d5d6e38b2a623b3ee7a307d6f2900fec902a1c6aad0669ba3ea3391d0561",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.tools.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.apidescription.server/3.0.0/microsoft.extensions.apidescription.server.3.0.0.nupkg",
-        "sha512": "0935055d9b547f1feb24c9777a9d44dca03bb2218311d9b541103c724adb7a5b447ebf87b390dbcadb9380f05ffcacacb2fd3ad738f285cb25f70dcb24c6ab9b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.apidescription.server.3.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/2.0.0/microsoft.extensions.caching.abstractions.2.0.0.nupkg",
-        "sha512": "fc1f7d3f267d86ce18ba04aeebce36b4047f5a7c3cb2342a4209d3c0f1b0fa2f07ce70ea82a85442e9c9a54ec3102d63e5b88098a3f7c08468a835fb51fb423e",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.abstractions.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/8.0.0/microsoft.extensions.caching.abstractions.8.0.0.nupkg",
-        "sha512": "1fdc30912cc1ead9362f70853de219a9dc7070bc28f621e387185670e605746ee2f13b0df9db03d0b1f8919d4bdaad40ebe9f8203e3a0cbb61145aa8848be136",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/2.0.0/microsoft.extensions.caching.memory.2.0.0.nupkg",
-        "sha512": "2b46b6dca1b37f2b45c4001f7c52c5195fe2d488f32e2658bf025a1772c875a04555e84991385bf50d51536f6c2d53e16c8e23253da07a52f95d23e15f1a6bd3",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.memory.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/8.0.1/microsoft.extensions.caching.memory.8.0.1.nupkg",
-        "sha512": "39d053a5a92f413d012f910df6716cdac2f1cacfd234531b956dfcd10f1a83ea8cb84d017d4c72e011f87c53db27e33e9dc7c86f842eacdb1907cb895b448817",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.memory.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/3.1.0/microsoft.extensions.configuration.3.1.0.nupkg",
-        "sha512": "314056d5e02a6d57b1f2ad1b9c2c59d27a7326d88a08c5b938758a08162d49c9b227e89354ff4fbfa47d2679c5d1463e3eca489033cd5eaa38a71422fc757ecb",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/8.0.0/microsoft.extensions.configuration.8.0.0.nupkg",
-        "sha512": "da48a8ef3b4cd2a6beb78008382d9fccdcdd42ff3a71d9efc5ac69d4020421294ac95b07cf11520341a69ee241925cd040d49a382df243e2fa194f6896ef9734",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/3.1.0/microsoft.extensions.configuration.abstractions.3.1.0.nupkg",
-        "sha512": "13ebe935f71a5447ecf5729d177816dbc00b052ed8908c7371f62aef3510614031f6279e694d6ea3baed141c91645568c98290e9445d6278db2455e28136d1d6",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/8.0.0/microsoft.extensions.configuration.abstractions.8.0.0.nupkg",
-        "sha512": "3316170910a94290c8df4fed26fa884a47dd9bf974eb7ad22368d5a63308660a01d2dab4a44662061dacaeccf4ba09cdabfccd4636f76ab3178becec5ad31a2f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/3.1.0/microsoft.extensions.configuration.binder.3.1.0.nupkg",
-        "sha512": "965cc4ee738f92c9059492de62cb6984db69d420d825ffb13bf03793df481aea198a6f343d922807659f5ab07c4e9440ad079dbd78f5898cec25a59a90245a0c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.binder.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.0/microsoft.extensions.configuration.binder.8.0.0.nupkg",
-        "sha512": "9a5931e9d417b8cd4903fe8b94aa8ec07a1f0d43386717be38171a5eb432b1765d7da95e7f092e6997eccf3f4828d5716317a68fcc8fed32f0ad4f1f82bb7223",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.binder.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.2/microsoft.extensions.configuration.binder.8.0.2.nupkg",
-        "sha512": "63f5d5d0f5df1c7f90a138c75e14d81f3598af78c2c736a7aef5035ffcf9d40ac5a133571935a08290ceb92db72357c8203261165f8f7f057c450b2c611f6c2a",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.binder.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.environmentvariables/8.0.0/microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg",
-        "sha512": "e7e284b1af1362db2ae4ee6df9fff7b4766df63861837fed0019a43388f688158b328b45dc9188ec966bca8e0f1efae0eca9be739b41de24702001942e103db8",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.fileextensions/8.0.1/microsoft.extensions.configuration.fileextensions.8.0.1.nupkg",
-        "sha512": "a9727a08418460a2c66da8ed447cd9ca199157e43e22b84fb0d642cfc4b7b74cb577c3bbd7217b6abc3742fcba7b8e35f873a1a289ee4315c09ce5f1b94ee9a6",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.fileextensions.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.json/8.0.1/microsoft.extensions.configuration.json.8.0.1.nupkg",
-        "sha512": "b61e38d1accfadeae40c670f9414eb360987db39024d0619986733334a63a88aed9727ed8fbccd2fb906f1e37f3b3df8baf01c1cb819b72f452c559f02cab37c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.json.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/3.1.0/microsoft.extensions.dependencyinjection.3.1.0.nupkg",
-        "sha512": "d1f4b1f75870cba2faf333c7a7e8d3bedbce69424b06840957f3be2e95c13ff43e9bde14d48efb982656f31208997eacae9cb1ba2d54b3ad6d49264bad727cae",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.0/microsoft.extensions.dependencyinjection.8.0.0.nupkg",
-        "sha512": "96391af4ae0542f4ae96c8009c9ffbf304acadf476cda262a8ea73e33b172529541044186c59d656377bb2de42c9f5925e0632a81f6e7516f2a646e8916f16ec",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.1/microsoft.extensions.dependencyinjection.8.0.1.nupkg",
-        "sha512": "b6d2c496ce68bf91ac7499eb2a8aae34347e648b9be853e535a36044afcf8173561650aba33068346f458062f29c8e0c1f5859f73800d512ec0f464dd467d00f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/2.0.0/microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg",
-        "sha512": "54deb3578c6430a23120fe3c910cd789e64f59751e18bdccd6742f8170a6e38100be2d9e0b48188ff95dadf3dd7b8245dd33b2a4010d66fb895f5aa44c50207b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/3.1.0/microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg",
-        "sha512": "e184edffadaca3c7782695c8d291ebdabb42bd1b67a0764355c6ce9a186f8d186de36924288eab3978d07318f3aeb6f14e1a883d6f69f8e69a1948486a3ae577",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.0/microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg",
-        "sha512": "94bc05ed29755109565d9cdfc901087ee1fa08302dda393106bc9a0bd7384f0dc2b6c2f123c1bd53fce06babdbfa845dc6d22a163c4b0646c5251dcc5aeac282",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.2/microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg",
-        "sha512": "ba1960ef110ac7387a2a06eefc02c59ce57b0fe58b3e0cccb79b1c8f2150105c5d1f4b65e0ed95ff50d70f28142917c6a735b83f4e5406bb1d8f9dd1f9635d7d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/8.0.2/microsoft.extensions.dependencymodel.8.0.2.nupkg",
-        "sha512": "42a9e54c51b5f99a1d26ae79ce21accb5218a600b2534632aa2c2a4cdcac5d2942d2976f2c915fe8523ec5e390043607ac6b0a530de9e7cbbad9e1841ecea37e",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencymodel.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics/8.0.1/microsoft.extensions.diagnostics.8.0.1.nupkg",
-        "sha512": "a668c7de32c39384a0dcf85abb12560b2e286441ae269b39efea7149bb2e4a90a8949d6f941b9e24b8b3642f15f86b8a968f36183d97695019bd23f0ea7be237",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.0/microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg",
-        "sha512": "a75dd040e3e03e90c8baa006bd569db9fd09983cf9c27bfcb246d96a73e2595cea7aee6116438989f8df31b56bc7fe6adaa7a7fcb6ab95ec5b1d64d0b17ff617",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.1/microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg",
-        "sha512": "267c18ce804b572b17d9256b41c544428c5586c144a6815f864408f08ada786ec8ec239bb7a89d985571ad3e962fdc4a059511439db4936c0bdbd660bf002f46",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/8.0.11/microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg",
-        "sha512": "b93febd5e681c26766d890feb34d1062ce66d44b84d1103f8c1d4a80ed0964ded8ef2551fd6bcfeab1d95fd8c5922733448954bece46d96c781b9ae984a08ef5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.abstractions/8.0.11/microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg",
-        "sha512": "0499640470c8390fee1a1fbc7a34efd4ef65f3ac93fe871420b6c844805e7711e6c98a9f3b1e9f1d8f598a247ef6d14e9dcdf3b442f31a65fd64a93ef3f64680",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore/8.0.11/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg",
-        "sha512": "962e83a815dd873648d722b9aa791298a6a6f1e82c11787f369babaa59fe45eef088f9556ec1e99a8ad9a18078339de3892dafbce4ed444d9e7a4d4e85135a7c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.abstractions/8.0.0/microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg",
-        "sha512": "fe9aa18f2e819694f20e322c93e075e27bee2d57ddd5380624fc48a95669c526c270ab5c74f58c6a4721d18ecdb5b2febf0315f8794585ae65617831459e2a0b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.physical/8.0.0/microsoft.extensions.fileproviders.physical.8.0.0.nupkg",
-        "sha512": "7612261a35b76d0b3a337ab262de57c3b605e8a1e55bf4d47f15e374e5577ab2ce4ae370980ef2c1335c4e323e6adcfe3718eee86570ac6e4ff5cb100450331f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.fileproviders.physical.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.filesystemglobbing/8.0.0/microsoft.extensions.filesystemglobbing.8.0.0.nupkg",
-        "sha512": "23a5e50cf695ba18c7a77f7c050e40d6fb065957480db17f5e75e5cf269c8f50763c996c28d0dcfca09e2c1248540898ab53c474cadc705548f5fe491dd263fd",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.filesystemglobbing.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.0/microsoft.extensions.hosting.abstractions.8.0.0.nupkg",
-        "sha512": "6788c16c139ba241cf2c65e4ded10b8ad8b38602b4490a5ff27dd52b02c90083b7cd40c7b4fac48aed94742f6545da959870b5d889b41078b22708acd761da66",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.1/microsoft.extensions.hosting.abstractions.8.0.1.nupkg",
-        "sha512": "4c7ef392ffc0c10a17b3bbc1232954fac16ed7e7e51aaaefd1e68f63eb19ca0b409f991bb72b4a1f9e7ecd241f196e579a2a740017cfe08b64c75062d60508e9",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/3.1.0/microsoft.extensions.http.3.1.0.nupkg",
-        "sha512": "7692b3ada00fff278826bede064e734889b0af77cc4a8f2865d40d2e7b437319b5f418abb1383717cc69aba94ea0c65de0c2683d52e3a10b788675e63bb72d21",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.http.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/8.0.1/microsoft.extensions.http.8.0.1.nupkg",
-        "sha512": "296bd0a65e3591df63d64e987c781c32fa677a08c84fe2911e6288eae94b1c77dd2a134692b5bfdcac93a4992fa14b69bbb81cfe3a1e7ff2e90d5babe917ec71",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.http.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/3.1.0/microsoft.extensions.logging.3.1.0.nupkg",
-        "sha512": "fd20e13f2908b212746f0b87df684bb3ca3599f40ceb72b7813be343b7dbef4d6865dd83c370d9ff719f88366f4998cefa481222e926db27dacc2493b610d415",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.8.0.0.nupkg",
-        "sha512": "aa30576c428dff69bac5f5d71721af6c4ef583bc524edbd0a94b49cbd80f698905021260e1a432c32e6d48ce5a30f6822c209f11dcf7c819aba1fa8347925b06",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.1/microsoft.extensions.logging.8.0.1.nupkg",
-        "sha512": "ab3363c4e103963ee5013ada55fddcd771961e48e5124f41e70589e589dacf27d20cff7e04bfc214db79fd937cbad80e99cef565f72e0cc10b84d9b3ac0619fd",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/3.1.0/microsoft.extensions.logging.abstractions.3.1.0.nupkg",
-        "sha512": "303b2749a54bbe683506e8981c39e3c3a9f76a08bc6eb9bd7ca7204079c6a88c68191a5247656e8c9138633be1a7758205b3bab92fca4a1e3a774b96315e6a63",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.0/microsoft.extensions.logging.abstractions.8.0.0.nupkg",
-        "sha512": "50a0add96d30d90580fb8e02a25cea0aa15f4d22744279b5acfe18cc8568b74402aa062d5db13cc5887a08bfd24e07cbc88b2fc10ee8eec2c37edf3bcda7f8a7",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.2/microsoft.extensions.logging.abstractions.8.0.2.nupkg",
-        "sha512": "f8b9df3fa7b837cb5f2fa53a86bfd47279f81bc332db55b8bb7ea14f55dfe2158f351d35199c0cc0e01c735f394ded2a3a8f1c85c3ff6ea1c3ab785bfbf362fd",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.objectpool/7.0.0/microsoft.extensions.objectpool.7.0.0.nupkg",
-        "sha512": "ee96a7f7ddda2557def993082c7d7429c25135b37b80df916f0427ee1349778722f10bd284810482662dee5c2f011fdb00e188626e7cde5c10c4b8718fef6639",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.objectpool.7.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/2.0.0/microsoft.extensions.options.2.0.0.nupkg",
-        "sha512": "afc8ef803afe1d832eb86f023bbbd5dc14b76583ce191338dfb2f7ff030adcec71d35aac194d4efcf0d08e5af572e2205e848fc137f8812f8ca85bde72e11e33",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/3.1.0/microsoft.extensions.options.3.1.0.nupkg",
-        "sha512": "643aac9c2d8d0aba135f9259d56d89a5d6b760723c694fd10a2ad3c8da291f535f27e94a733fbd7f80f208b1fd98ac6b5980c6546a3a1093eab40d7bfd617a9f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.0/microsoft.extensions.options.8.0.0.nupkg",
-        "sha512": "1c004082a132e7b75a0c95acef3578a4d5db42c55e0996e40b95b663e9a83c5a20ed481a85db7567fff7e3de3dbba6a7d4fe5c825dc7ce95de956689afa16c5a",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.2/microsoft.extensions.options.8.0.2.nupkg",
-        "sha512": "cc0c10336580c9519740a042b1e42d391bcb32b63732163ae1161e1c5b55a4cd4a736e1902eb2a4dbb89d784b0acf584b5042b4f3481a61dd30a4e229fb523c5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/8.0.0/microsoft.extensions.options.configurationextensions.8.0.0.nupkg",
-        "sha512": "5c32ae67ae4e873216bbbec15554778e0acbebc283862a2debcb11a995c42a5fd75f9436c8da421aa51bc5c12db4e6c4e82f12da1ff942bc5a6e1a8cf3c77a7d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.configurationextensions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/2.0.0/microsoft.extensions.primitives.2.0.0.nupkg",
-        "sha512": "47284b149a0cb337dbbb5af3fe0ce8aaf3ab760b275f193407f3387ca8ec25d6fafc8dedd8c755ab8b35756b3c84e5ca8dcab6ea8bec2cbd543cba304ec69371",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.primitives.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/3.1.0/microsoft.extensions.primitives.3.1.0.nupkg",
-        "sha512": "abd8306bc481c1aa6ac016576e2be6be4332037af80dae407896727684e799d5147af2fff39a05f5be3e864391d5753897b7f35d8c57fc7221f5c4783e002ce5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.primitives.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/8.0.0/microsoft.extensions.primitives.8.0.0.nupkg",
-        "sha512": "1f5475ca3d3ce18463456dd135afac502d6f82fea6e4e4814a61f86616c348decf28b73d15c2bb276d1a3c039ea6064f75e1329f6f3a64caa3520d70ab92c32d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.primitives.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/8.0.11/microsoft.netcore.app.host.linux-arm64.8.0.11.nupkg",
-        "sha512": "629914865afc8a5df3312571ffb43d64597b092df1fed720752236c005f2a0ac48c3a34e8f597b8a510176adaa2759cf6456e073925f4d425304c1ba6a14b3b0",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.linux-arm64.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/8.0.11/microsoft.netcore.app.runtime.linux-arm64.8.0.11.nupkg",
-        "sha512": "d40eb91197dc6c08c9e2cc72708fab91edec68d3225a0946e8d4f1859e53103461947cb897c16dfc63e7c287c5043e72f2c0ece476ecdf5f2ae5755ba6a10bd8",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
-        "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.1/microsoft.netcore.platforms.1.1.1.nupkg",
-        "sha512": "9835090f578b5c8ce6527582cd69663506460e9fdc5464fc2b287331c24d9369e57dd1543a865a8bd89d4fcfc569c26bf0dbfcce102675fdfd1479b9a9652819",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.1.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
-        "sha512": "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
-        "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.openapi/1.2.3/microsoft.openapi.1.2.3.nupkg",
-        "sha512": "9d8710a99c1a976014c0a4a837d021fa58fd13d5c1d573861e357c43ab1b4ea73ea85cf72afab0a3dfa5738908ade7ef6904e2d280ffff2ad9cfc8868c228461",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.openapi.1.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
-        "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.registry.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/8.0.0/microsoft.win32.systemevents.8.0.0.nupkg",
-        "sha512": "25016c508653fbf463c52d8fc3d2773b7c211c2402c4ea7b4aa987fb29c851d3f80c5e7abbcace2d4d5e061ae290524e8029afbc49a37d7e5186fe06aa4609b2",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.systemevents.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mimetypes/2.4.0/mimetypes.2.4.0.nupkg",
-        "sha512": "3d25e35d5e893dff932db404e2d9151be7da8e1cffe213d7689199dc81b337472e24fb6517db5fbb481f05676abd0b367f2e8ddc8b6a97af4dd6a273531e514e",
-        "dest": "nuget-sources",
-        "dest-filename": "mimetypes.2.4.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mono.nat/3.0.4/mono.nat.3.0.4.nupkg",
-        "sha512": "b2909720dc40cd459741e4ad9af16cf8289dd43f5fe1f90a28f26937da8d8ec4621d3b296019a94bfe5c871ef12b41f49dc85c415e656d5376a3b1fa48d63973",
-        "dest": "nuget-sources",
-        "dest-filename": "mono.nat.3.0.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mono.texttemplating/2.2.1/mono.texttemplating.2.2.1.nupkg",
-        "sha512": "22627ee103feee11c04c4eefb33b3ff874cd5553c71a4287266465b3bedf9803d27bb998ce736c9b977f79b436a168823a9d33637183ce466470c098187acb6f",
-        "dest": "nuget-sources",
-        "dest-filename": "mono.texttemplating.2.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nebml/0.11.0/nebml.0.11.0.nupkg",
-        "sha512": "07dc3630b81d5e4a29be8df8178d6fba6f7bf20396bb5217af2941b741d88764e0a91e8d524249a9a94dbe8dfd5f128e4d8556e71404d63b521a493a8ccd9965",
-        "dest": "nuget-sources",
-        "dest-filename": "nebml.0.11.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
-        "sha512": "99b252bc77d1c5f5f7b51fd4ea7d5653e9961d7b3061cf9207f8643a9c7cc9965eebc84d6467f2989bb4723b1a244915cc232a78f894e8b748ca882a7c89fb92",
-        "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.13.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/playlistsnet/1.4.1/playlistsnet.1.4.1.nupkg",
-        "sha512": "903c52d34062831b99a6d632f175e22e9afb247ae3618bfce8018b0595784264f0dbb0b63bf139d65dc8e34efdf15bce9e7608af1a8dee87765523193f85a850",
-        "dest": "nuget-sources",
-        "dest-filename": "playlistsnet.1.4.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/3.1.2/prometheus-net.3.1.2.nupkg",
-        "sha512": "140f9817fc9da297eeea6b7b6d03303d53364268bbda89cf76f56b37692c94c6fa160c2d0d475fc1d07857a64f21b0c7202178a5aaa0e64048254b6a0a439ad9",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.3.1.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/8.2.1/prometheus-net.8.2.1.nupkg",
-        "sha512": "f7094a591be84d1b8171081cc0c30e8ee4d2adb9118eb52fb53830f789de29960e86e17278dd44da439b5e463151fd7602dbf5bdab838c2b4626812b3d2a4ccc",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.8.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.aspnetcore/8.2.1/prometheus-net.aspnetcore.8.2.1.nupkg",
-        "sha512": "3ab7a9556aabfb429f87478b6e7e4eaed4445832189c670a245e8c77349946c6c2b278f30e6bfaa9ee9a5412789b300a70d96d5cf5d5f1b42b996f70e9660ffc",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.aspnetcore.8.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.dotnetruntime/4.4.1/prometheus-net.dotnetruntime.4.4.1.nupkg",
-        "sha512": "62712e2d734722927f6ee382dc4341efd0267549197dafa300e57692d40b46e7640d12c14452c0a9d298bc497b2831354fa531403ef64a0c8a187f1f98d951c5",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.dotnetruntime.4.4.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
-        "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
-        "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
-        "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
-        "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
-        "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
-        "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.0/runtime.any.system.runtime.4.3.0.nupkg",
-        "sha512": "bfee3c68312296860e5459af5e770c2e9fcd4ac134361fd569a9ce1e6574b9ae3978aad403f89639a4b5bac8ee5bb0ee1b8edb819e9a60f13ca5bd1812889bbd",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.runtime.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
-        "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
-        "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
-        "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
-        "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "8f071552ee042f0cba39b1ba0a1205cf73de447d662995bae68f857a5946f7d154c029a79e37469081675687873c8bf2b9efe57f5cbd660c366b1ca51823f7f2",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "a135ca0f4f5a49319b5a52b7f4338f8a5fc4387edf26f29e6cbf63a3c3a37b2b5c51c9caf562ec41e470fba281060362465bc56915be782d6c75778aa6195e46",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "2f24e2cba88a96bb23848e1404878e4478a65642387b7b76aa4007587fe7c4d8208cbde53d3ed65f8d0d71cd688bfc16be66dc5f7bcf84c7b2ccf1b3c505b0b4",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
-        "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
-        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.2/runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "a34ad2dbe67efcae97fcbea57af386b30660a98ab8229a56c0dca241316e673cf7a26e19c6efb6b7117cc271fdf208741ba6f8447ae254c91acba3ddb7d2923a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "ce0873e07000df98e640bd265e969d4a9236535cee2699c5363f3ab297557b0d756260557995f2ee163cff05fc2ba922d66ba0e4cb28521f841e7d546ab3b63e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "bf754c1a66cd70dc1bd38d54fe675e9dd470417ebba62e2f79e278be8f06cc3496ff58ed90d30b5dd4d3efea9accbd09eb17cd87be882951c0fdfb833c371f70",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "cd4b7ba744de80086521ab67cad2db3085d488388d3d9cb83d9946389f0f4c784539bf3a4ffb8d4f3347c5c7813aadef95b355fd2563e30c948a883c27b95287",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "d7fc28a9f600e471edce0989c01c485d4e2a7e99551f531413afa75039a4004d4e2c27e88976d65432635a321d86316a3c6cdaebc7b2fefa42141b64f4f10d66",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "5fe0e6a878eff59cfe24a8d57af51140576d8e0fec4988e4892c233c47b3a3eed27dec072a6c0d55dd615777cd9ce3fe545c5353b4a95289376ad0b9408ed4be",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
-        "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
-        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
-        "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.0/runtime.unix.system.private.uri.4.3.0.nupkg",
-        "sha512": "203ebe272791d79ab0c40afe9d0543852ee91b9fb4ae5bc15524d97728bc8bc9d7e0cbcf65d1fab8cfb0aa7a4ae37e7938933eef127aa5ea46f60e57b6ad2d91",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.private.uri.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.0/runtime.unix.system.runtime.extensions.4.3.0.nupkg",
-        "sha512": "54b81784c08e934389c59e6e155af6b1855e4bbc41678b01a702c94e6daba87c6ddfd16fe9e2cb61f3097bfa4950dbc37781454d027ce5ba6c50a393cc91b888",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.runtime.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/3.1.1/serilog.3.1.1.nupkg",
-        "sha512": "02985d43db0efd5e56b086e0a29af986de381a163a8633ab81a88b6620a3df380afc4506366beba0f214ac8ec37c8d435bdf130285dcde331b14733e62fab8c7",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.3.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.0.0/serilog.4.0.0.nupkg",
-        "sha512": "1f6279bcfa93ca9c13180dd7c7e5944d5351358b9cd3a360cbbf12f2dda508700cb9ffadeffd4dfe772a6ddb2c029e2c3473e655a3b660a644de51d67133268c",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.1.0/serilog.4.1.0.nupkg",
-        "sha512": "4b0bcbc6ef35b4d1914dc870f3ecafc4a7e320b66842f8fce03d733874fd4d171885343c91e43dd1d5e49f55c50f948cf6c681c64819a8632187309ff82be15a",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.aspnetcore/8.0.3/serilog.aspnetcore.8.0.3.nupkg",
-        "sha512": "d46d53d19ea7c1c00eab3064fc995ca7d455df983355490d4053a5bb6e51164f74e007d4cdf1ed20de7c85b19bb65507f61645f2c3472cc386fe244230bd5f4a",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.aspnetcore.8.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.enrichers.thread/4.0.0/serilog.enrichers.thread.4.0.0.nupkg",
-        "sha512": "d776603c04a031634dfeb64203e3ed4204eb96d503ac8183d5ba231259c55cd4411359116164271e38ddb949a9c4604f4946021c52c34044cda85797e6b4a7c2",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.enrichers.thread.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.hosting/8.0.0/serilog.extensions.hosting.8.0.0.nupkg",
-        "sha512": "580cd1e3c1099bb8774504409e59cca246dc1e5754cc6a0e2085ca03c4ecaf66088e284d854c235578db3d0a449a854015454b686c0bbb1c299ac9c052e14a6d",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.extensions.hosting.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.logging/8.0.0/serilog.extensions.logging.8.0.0.nupkg",
-        "sha512": "cbe725d5313d4cbfe551ba20b6686ea02c17a6572b79170d312b3e31e3763b544276de387bfadd98bf623d602aabd5c6fcd131a2a29dbf7204c649a86d1cd8f1",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.extensions.logging.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.formatting.compact/2.0.0/serilog.formatting.compact.2.0.0.nupkg",
-        "sha512": "a4a87b075d4dea0f3d481669206a6488890e5f4e5615be587b9d4c74ff0b8bea260fa19e85610ef24ce2ce7af49cd561f4e2212769559352aac9325a234462ee",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.formatting.compact.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.settings.configuration/8.0.4/serilog.settings.configuration.8.0.4.nupkg",
-        "sha512": "04f71c87368908aa672326229cb5286cc14565124f539b2d19e4524a50bacbac9b4686c0cad52c8f0324e288f13620e0154a7b64d5abbd176a100b33ca32cc73",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.settings.configuration.8.0.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.async/2.1.0/serilog.sinks.async.2.1.0.nupkg",
-        "sha512": "04c6181f987cf459d96ffafca2a7cb7d5bef0f5b079277deb5ac009d238929ff8b075b2e73504330505462d76652ce106966dd3a0407c8799bfe5d0bec7f0fdd",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.async.2.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/6.0.0/serilog.sinks.console.6.0.0.nupkg",
-        "sha512": "49c6a20f42a9b46d8cccd76d287e92210aeb967d8f8daf93be82561fa050d91f927d0bb5ea81a147caa899b9abf47b616e5d74a8cfcffeadc1545da0b73a979c",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.console.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.debug/2.0.0/serilog.sinks.debug.2.0.0.nupkg",
-        "sha512": "fbddb39441be29aee4077c487e321ab0c3a167adc74f698115a5412d989e4d33c2a8d1cd9fcb96b312c567cb293d23f8431c936d9647691e019600a405c5cc6d",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.debug.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/6.0.0/serilog.sinks.file.6.0.0.nupkg",
-        "sha512": "90daa5403374597318b8973f4a7725dd14d44425a75793c82baa4143aeb3b4aeb8423636edd2b3b82a9df367d4e42339e73baaf62d42c87e7d4a958fa4394609",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.file.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.graylog/3.1.1/serilog.sinks.graylog.3.1.1.nupkg",
-        "sha512": "4509679ad467ca5c96344e08ed507684acce267d31865c3057bf1eed88fa2b66f9fd85d142669dc2fbc891ed82a04fc45d82aeb65d0ff2f4a4903fde37926470",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.graylog.3.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/seriloganalyzer/0.15.0/seriloganalyzer.0.15.0.nupkg",
-        "sha512": "c0ddb69f4e0ae258ceb8ce7ee6923b6aa6f815246a347684832fb7c08f9af696435a11986b73b2f9325138bd3da0932681127e166102f6a6b92943bd0c0e3e06",
-        "dest": "nuget-sources",
-        "dest-filename": "seriloganalyzer.0.15.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/2.0.0.1/shimskiasharp.2.0.0.1.nupkg",
-        "sha512": "babb41bfc0354dea0b52cc70ea9e9510204e33b0a8f544ceffacfaa919bc7ba26a24493ee70fb5a30758320380e4d88163a7daee0f663602db0365956eb7c0d1",
-        "dest": "nuget-sources",
-        "dest-filename": "shimskiasharp.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.9/skiasharp.2.88.9.nupkg",
-        "sha512": "3a2ffa5e05f45cdb80e6735ee947e91e08ff145fc50c7882e75d44b6ae0c2cd733420d15b6a4274a186b3a79d463a1273e27ff7fd79a51d0937251ebb6ef761d",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.9/skiasharp.harfbuzz.2.88.9.nupkg",
-        "sha512": "7ebc75df46b3d2bfb110324dc0613fb1395667219ce42c757fb98f0ff60b755fc69fe6bb94613a2be854e8feecdebe671ea46cd9e8a0df2e90ff7d461ab123cf",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.harfbuzz.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.9/skiasharp.nativeassets.linux.2.88.9.nupkg",
-        "sha512": "5c6a3e93a18e70e6adcd548bd2f76fa311114346ce4d812e520f250d33342d5ad8d05ea285433bd15cb19bbc48d9bbf2ef7d1f1725dd71705accefaba3f46892",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.9/skiasharp.nativeassets.macos.2.88.9.nupkg",
-        "sha512": "74cfb865746f2911935290bfb92469b331e50415d5abeda87598ebdb4049c52af84a5daeda41ebcb0bbaec6a7debb42d83cdc6c9f61cea55d43c720a78c3ebce",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.9/skiasharp.nativeassets.win32.2.88.9.nupkg",
-        "sha512": "d18bd8194041c7ffb79302d4f1be584e8c024e88b12cb4669a738cae551da3d3e3924087bb0aa42d34a9003cfb35037d73637894e67d02223d100a1b4215eeec",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/smartanalyzers.multithreadinganalyzer/1.1.31/smartanalyzers.multithreadinganalyzer.1.1.31.nupkg",
-        "sha512": "0e703633c4e989fd218620ec76a21bbbd9dce34f313ea1dda8d698be11ffaf08d959b8e2d9c964aa661e7dff3611003504c757ce8cc956d8626fa2ab21c482fb",
-        "dest": "nuget-sources",
-        "dest-filename": "smartanalyzers.multithreadinganalyzer.1.1.31.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.bundle_e_sqlite3/2.1.6/sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg",
-        "sha512": "69169044def48e943aac624d83be72ae09b046b7f4bac1efcd2aebbe02fa9847ad8bc5303b05834b39880c05e33ce64a51a34f5887a13bbc35761d72ce086baf",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.core/2.1.6/sqlitepclraw.core.2.1.6.nupkg",
-        "sha512": "16bc39cd5325dea37e1564fc328a35966d6d820878290d945dc57496b716d4935b534285989af32fa7bd25ef9a8ac795b63e6a19044d3f84a104d643319473be",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.core.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.lib.e_sqlite3/2.1.6/sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg",
-        "sha512": "69543fcac6af6520b638ed00c5f8f8dc59747376382c561ca82904780214b3e75cc4293106c4a3f6f671b73d591195800c44afa2d4dc533a8257b00fdf77d663",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.provider.e_sqlite3/2.1.6/sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg",
-        "sha512": "527cec74f2ebeff238b3bb1f898637576659537aa6f2c5a4384b1c1b094cb772bfe86f05c13a1020247bd73fed8759c0bf568a1c0059c1d87bbbed2db1018701",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers/1.2.0-beta.556/stylecop.analyzers.1.2.0-beta.556.nupkg",
-        "sha512": "08163f6061ebc26ea9b8069a82e9f575d656a50f1d9299eda874f4107731eb2e02b512f201f1c34c6983d92baecd6ee5e992aa6b61c78ae9490a7fddbdd51882",
-        "dest": "nuget-sources",
-        "dest-filename": "stylecop.analyzers.1.2.0-beta.556.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers.unstable/1.2.0.556/stylecop.analyzers.unstable.1.2.0.556.nupkg",
-        "sha512": "0e9fbae713d2d30690bb331e7308a619894ee26c13798855ec0a2529b32468d67fbcf2bc1f02aa0f3ae7e6851d2b595684ef415245aa8119b9b1b7d58c30916b",
-        "dest": "nuget-sources",
-        "dest-filename": "stylecop.analyzers.unstable.1.2.0.556.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/2.0.0.1/svg.custom.2.0.0.1.nupkg",
-        "sha512": "0ccdaba6b38665c31d2e660a5983a980584a7ebb1a999d91cd3acfa3861f68a428a663f3fdf24093bed52f7628b9d2ea020a1ab6614d846c6c8a2515b90b2312",
-        "dest": "nuget-sources",
-        "dest-filename": "svg.custom.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.model/2.0.0.1/svg.model.2.0.0.1.nupkg",
-        "sha512": "a02226f89e5c5ce81b49a1a38bda8945f070849fcc557fcf3ad2f500430c0e1410ee542681fc8b7a2d560c4bc00a084f58f96f001ded0ad94254d1e2d05fba67",
-        "dest": "nuget-sources",
-        "dest-filename": "svg.model.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/2.0.0.1/svg.skia.2.0.0.1.nupkg",
-        "sha512": "eec0ec97de78aca75af5aa5523df5afefdf7a9cdcea0379669d001a82b4fa3a3882a82614b4ab25c6436a48c9834d3d1e19e669fe32d1396d4c8bb6c712a94ad",
-        "dest": "nuget-sources",
-        "dest-filename": "svg.skia.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore/6.2.3/swashbuckle.aspnetcore.6.2.3.nupkg",
-        "sha512": "3e491d5f00e2ea8c26170ed72c0ab670beb3d8178baff82a4aa8e97986791f65125c62a73e413d5d6b435ca2205e2bbe92d6e542a504a7ad2cce552eb3548f93",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.redoc/6.5.0/swashbuckle.aspnetcore.redoc.6.5.0.nupkg",
-        "sha512": "0a2d7427dd148741e5761818cf9a920b198fa235304abc00310b56dbb94147734adbadd7c0a3fcfcc32b1443609b248842e8611849c0a3f56419a4b3007f1488",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.redoc.6.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swagger/6.2.3/swashbuckle.aspnetcore.swagger.6.2.3.nupkg",
-        "sha512": "c12fd032b76e9cbc4697b3bae1f123807410e3d5a8eaf3558a1840880f8bd30fa5dc4b316e86575310eb6eec1924467e0c9c02631afb10e20ec9eead6da3f439",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.swagger.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggergen/6.2.3/swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg",
-        "sha512": "777f7ac29a52dd45bdcbc4a2f426e12f5f8918b9d7e018b4cb8c8f26cb2f40bec77378c9cff23a951170559a9ef4b24a25ab2a3a2ddff63a30cec9240e535912",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggerui/6.2.3/swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg",
-        "sha512": "90e6aafa82fbdcacba8b48a2f59bcb6418a5ecab7e7d659b44ce8d8bc5a3aa97ee168e85a971e8d4cc5d78e3e1f9e2a5cd0e9e4da09cd8d32f898eca4f74b397",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
-        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
-        "dest": "nuget-sources",
-        "dest-filename": "system.buffers.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.codedom/4.4.0/system.codedom.4.4.0.nupkg",
-        "sha512": "13f96f49f3053ed35f94081d33a02e3d4f096d976a752a06a54eba1bb4ab76e0aa76b1723df95aaaa57880dd9dd21ac2069bbdd876a8aa950fe5dfa0f48b5cc7",
-        "dest": "nuget-sources",
-        "dest-filename": "system.codedom.4.4.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
-        "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
-        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/6.0.0/system.collections.immutable.6.0.0.nupkg",
-        "sha512": "f8036412e384c5c5af6d28f4eab2543207d2ebbb16c47b70f6c471bc5aa4b9f44404c47d776d295191f20a89caa898abd73a2304dcaf77979174ced2d9160169",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.immutable.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition/6.0.0/system.composition.6.0.0.nupkg",
-        "sha512": "48618297e7fcf02b05bce032bcde1882be780e0e6d156b8312855f2a2d080ff590fd7bcc7a296ebddec9d82f654d9286e42b424ce07b112a449be2bfb29bcb8c",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.attributedmodel/6.0.0/system.composition.attributedmodel.6.0.0.nupkg",
-        "sha512": "a53c30b3cfeb4fc67741e85305707b324481a6ac394fb1af71acda01309c090557424a4352135effe0dc37c2953634441994328d89c22532d8fdf8eb7f717405",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.attributedmodel.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.convention/6.0.0/system.composition.convention.6.0.0.nupkg",
-        "sha512": "f4dd753fa196325d1a5e9a06874e88d9651f812f48b013608efe322e079ba194bdf4587603bcd71a86e33f53103c48b1dc8f1776842d5dfb4afbd7e8b4e9dd02",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.convention.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.hosting/6.0.0/system.composition.hosting.6.0.0.nupkg",
-        "sha512": "5a5a331c91f12b6cb63c5dfbea1095980a0a0bfa5d9e336c7316245706f6bedafd76a0b6880ca2c79415f31840c231730285b9bcc3b9474659a28ac9fdabd03b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.hosting.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.runtime/6.0.0/system.composition.runtime.6.0.0.nupkg",
-        "sha512": "ccf6d0fa4a8bb6a170121281728e965df4d346a69c55e0ecefab6b8241959876de568462b7d5dbd290aa6e510cbf1973802466e99b59a7e95b92889052acd79f",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.runtime.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.typedparts/6.0.0/system.composition.typedparts.6.0.0.nupkg",
-        "sha512": "8cf43d8d159dc065c04ad9ec09a60ff431a2fe5fb3d4821c04a02a11687ede9bbc900d82f6d4d6f5d298895c664afbe0e6982b63a20059c5884bdb8c265793b7",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.typedparts.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
-        "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
-        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/8.0.0/system.diagnostics.diagnosticsource.8.0.0.nupkg",
-        "sha512": "86e32c62e9773dba192a63bff0e2ffcd57826ed1123c9261fa8c9229f9d1dc26962b3740fb025f6ad5c139162575a6c493b213a9ef3fc1747d15ca0edd0c5878",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.diagnosticsource.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/8.0.8/system.drawing.common.8.0.8.nupkg",
-        "sha512": "318e393b68d144d12d3a41de0dbdaba6796c7be03bb70ead38b5ee7f5581fe059ce78fb39cf4d8e45f1c8ecd194a4b38ff20fd034beeb79a56bfd6a8e33eab52",
-        "dest": "nuget-sources",
-        "dest-filename": "system.drawing.common.8.0.8.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
-        "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
-        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
-        "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
-        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
-        "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.3/system.io.pipelines.6.0.3.nupkg",
-        "sha512": "a72246cbe26c5a7ec098f69798063076731529a3b2e555a3d41692ef5496222328d3988cfbd8e23a54e474f5429df3e478537f85e0dbc145d2cf3c263dbe726e",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.pipelines.6.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
-        "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
-        "dest": "nuget-sources",
-        "dest-filename": "system.linq.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.async/6.0.1/system.linq.async.6.0.1.nupkg",
-        "sha512": "792b7b14a6fcc52f88cc0475a2ba8a694399393fa602446fe23fa6d39d782c16f908b4bc3acd58454554932b7a41056d84424b5fd66f0fe6e3c00178eb3d8a1a",
-        "dest": "nuget-sources",
-        "dest-filename": "system.linq.async.6.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
-        "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
-        "dest": "nuget-sources",
-        "dest-filename": "system.memory.4.5.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.4/system.net.http.4.3.4.nupkg",
-        "sha512": "163edeef734d1f0a1ff7b8053d326eabc82fe86f3de72c6466dd780d59d974487882f2a5f16ae4b02c0d8c8a7f25e617ff2bbfab133f88ebfd6a2f99637169ed",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.http.4.3.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
-        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.0/system.private.uri.4.3.0.nupkg",
-        "sha512": "5989a57ef273b689a663e961a0fe09d9b1d88438e5478358efc4b165de3b2674fa9579c301ce12d2d2fa5f33295f2acb42eceea2ebebf70c733da6364ceaf94d",
-        "dest": "nuget-sources",
-        "dest-filename": "system.private.uri.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
-        "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/6.0.1/system.reflection.metadata.6.0.1.nupkg",
-        "sha512": "7ae13917018aee2c9074db134aaa27cad2d71072f7d80bb13dc16b1de16cec62503b064914d12d86326534c9ed29dbbaed5fcdab7f88b620ae1d1c5022b4673b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.metadata.6.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
-        "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
-        "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
-        "dest": "nuget-sources",
-        "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
-        "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.4.0/system.runtime.compilerservices.unsafe.4.4.0.nupkg",
-        "sha512": "d03f39b62f48714c56aa5db5ddde1613e7f62633734731e611a1b7e2a880de10fb1bc3b88b4320afe46eb649f8a66adbad6f80058e2fce910280799dc3ebd38d",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.4.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
-        "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
-        "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg",
-        "sha512": "0a5baf1dd554bf9e01bcb4ce082cb26ee82b783364feb47cba730faeecd70edc528efad0394dcce11f37d7f9507f8608f15629ebaf051906bfd3513e46af0f11",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.handles.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
-        "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
-        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/5.0.0/system.security.accesscontrol.5.0.0.nupkg",
-        "sha512": "ae6b03ad029d3eb6818a6c8bb56cf4904013fa535a67b8e621b783a029dd88aa2e471e002cbc7d720381ad8bc8c6b93111a08f6ce2d271af6d974bf4d02b6c81",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.accesscontrol.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
-        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
-        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
-        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
-        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
-        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
-        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/5.0.0/system.security.principal.windows.5.0.0.nupkg",
-        "sha512": "44a920aaaf22b2172d41319bb57ab2b8e1a4531d5f02192a6f53a81d875125195b60ba0b5a44a45981d137fd7b0f3a65b12959b5fd97afc0578cd84ef27467cd",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.windows.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg",
-        "sha512": "6ff7feec7313a7121f795ec7d376e4b8728c17294219fafdfd4ea078f9df1455b4685f0b3962c3810098e95d68594a8392c0b799d36ec8284cd6fcbd4cfe2c67",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/6.0.0/system.text.encoding.codepages.6.0.0.nupkg",
-        "sha512": "ec873a95ec517de2c5a5364ada30974ddd5e0fafef2ad2517609a1900b5059d35757536fd073805001fa68d5b56a3d4647010a96c9eb233b1d172a3b45fbe4a9",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.codepages.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.8.0.0.nupkg",
-        "sha512": "77dadf6b1a73eeefb50507a6d76f5e3a20e0ae7d3f550c349265ae4e0d55f0ae4f0ef1b41be08dd810798a8e01dbba74e2caac746b5158b8e23d722523d473ed",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.codepages.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/8.0.5/system.text.json.8.0.5.nupkg",
-        "sha512": "13589021ae3e81f54c877abf613ce931cc24ca57bf127af1063ccc1eb4dc57a6cc223a61e6452207f5d0dce453b6627430e31e4143c78e71e9b5dd647f680abf",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.json.8.0.5.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg",
-        "sha512": "97a2751bdce69faaf9c54f834a9fd5c60c7a786faa52f420769828dbc9b5804c1f3721ba1ea945ea1d844835d909810f9e782c9a44d0faaecccb230c4cd95a88",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.channels/6.0.0/system.threading.channels.6.0.0.nupkg",
-        "sha512": "32adff895c57ab9ef864cf89660403f041b07841be7c44a0c3c2c8451a1da076a8c1b4dcf1c993b585304ad7549afa408a0f797ad6814d0f14eb748a1fc9ce03",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.channels.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg",
-        "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/8.0.1/system.threading.tasks.dataflow.8.0.1.nupkg",
-        "sha512": "24622fd7d5e33cb55309d0dd35616aa3d6e7aa0c66e1e597c0ca6106cb26cc4248349815139c8f00a51e062506f5fa5f6cffeaa6fe8cb030c64b1d6952224ab1",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.dataflow.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/taglibsharp/2.3.0/taglibsharp.2.3.0.nupkg",
-        "sha512": "9be37f6431f6ead36babe78dc6527340d7b4b0fe444736aaeae5aef3651191d4e0421d9d671106aea544888695d7841000fb12f8a44aab1b5fe93fb7c90d983f",
-        "dest": "nuget-sources",
-        "dest-filename": "taglibsharp.2.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmdblib/2.2.0/tmdblib.2.2.0.nupkg",
-        "sha512": "ad0cb6ad203d1ce0f0f2f9f96140326abc0fc54e7b79e38846f6d3431e5c0f17bbe689cd52059931f52f258b16a2ce55fb9f7b2c7ca6b800542fcaf257a2774f",
-        "dest": "nuget-sources",
-        "dest-filename": "tmdblib.2.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/ude.netstandard/1.2.0/ude.netstandard.1.2.0.nupkg",
-        "sha512": "29c5e5a43cd2a0a9dc770ac3ec9976c5ef922622d114bb12cfde950f58d45fbd385e013d170df6fa2d45f9c56d29738bb4240b4f1c3a0e3908d9f99ff938c3c0",
-        "dest": "nuget-sources",
-        "dest-filename": "ude.netstandard.1.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/utf.unknown/2.5.1/utf.unknown.2.5.1.nupkg",
-        "sha512": "342b4a01af4cfb0a0b77de0afd7c6393fafc124e72b420ff1f7936891aa259e6a55129d46e54eb5d7fce9759a6ab52ebec89045fcffb23148324ebaa7b604629",
-        "dest": "nuget-sources",
-        "dest-filename": "utf.unknown.2.5.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/z440.atl.core/6.8.0/z440.atl.core.6.8.0.nupkg",
-        "sha512": "e52cd9acbe0eba1c72c6d2967a314198421e029ca0271e4872f37044549173d3403f33e2d391350356c96772938d1fa95ba9c914b238b3929d3c9293469c3fd5",
-        "dest": "nuget-sources",
-        "dest-filename": "z440.atl.core.6.8.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/zlib.net-mutliplatform/1.0.8/zlib.net-mutliplatform.1.0.8.nupkg",
-        "sha512": "c329dc559df3eb4b4bf2f832f37442af6d1be625c97a904f25bc4078684e4716d769ee2c1215329e78a299ec0f6c8a90d6ed1e3116162433f490a7bb54d30b52",
-        "dest": "nuget-sources",
-        "dest-filename": "zlib.net-mutliplatform.1.0.8.nupkg"
-    }
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/asynckeyedlock/7.0.2/asynckeyedlock.7.0.2.nupkg",
+    "sha512": "3531c49506ca4166791bc4a394d00690c35c52a5ffa1f0946bc02cf9ead793f82f933a6c90ec85ddd67e97723ca56da998cf3a586cbb75db1fe39bbe64b479c7",
+    "dest": "nuget-sources",
+    "dest-filename": "asynckeyedlock.7.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/bdinfo/0.8.0/bdinfo.0.8.0.nupkg",
+    "sha512": "b9b3e42e71def59d5150ad4a830f8792b39bfd1964a5c975e509fcd47569cbaaae763da098346f852f90dcd5c82bf9136d3130819d12c1452b2b9f21cad14367",
+    "dest": "nuget-sources",
+    "dest-filename": "bdinfo.0.8.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp/1.3.3/blurhashsharp.1.3.3.nupkg",
+    "sha512": "7a49ff313da159a1aefc91279c77eb7265a52c50118e4b91d2174a225edfaec13051cc49023fdc4c08ce52635bd68d88e1de9c5968d885fc0d5e53934ea96c17",
+    "dest": "nuget-sources",
+    "dest-filename": "blurhashsharp.1.3.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp.skiasharp/1.3.3/blurhashsharp.skiasharp.1.3.3.nupkg",
+    "sha512": "f17106411b69a58580e0854a662d44623445e96866d6cf8834865ff978dd1f08ab5646632f35799ed53f56d13d5624efa0e44f60bf10b116c0459c41bc9b2fad",
+    "dest": "nuget-sources",
+    "dest-filename": "blurhashsharp.skiasharp.1.3.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.9.1/commandlineparser.2.9.1.nupkg",
+    "sha512": "4f364e45c9668c7e7cc6a922b488f3fa523033c20d7a432694f0a6af05ce528ea0481d8375e2f4f1032c6990347b4803ce9a0e48068c6fe15ec46fb1254f085d",
+    "dest": "nuget-sources",
+    "dest-filename": "commandlineparser.2.9.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/diacritics/3.3.29/diacritics.3.3.29.nupkg",
+    "sha512": "48d53debccd23a0cea558199f19e26313db0d56f5e65cd9b5866b2c4bc9ccd2273088be9528eba504b43aefdcbc44f2fa54ae175e2c8e5fcbec04fef92be5382",
+    "dest": "nuget-sources",
+    "dest-filename": "diacritics.3.3.29.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.core/0.16.13/discutils.core.0.16.13.nupkg",
+    "sha512": "637e7448e43b8f022858b88073b9a10a937af6878846734ca19eee56af7d0f66a09aec007948eb50b16fc09c78b5526c38773487e956d906566d66459551c47b",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.core.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.iso9660/0.16.13/discutils.iso9660.0.16.13.nupkg",
+    "sha512": "6c9e2c62e2e25c119da650d5991375618f61d7935856a19ddef1f5626ccdff7ada3b32443e03272cf1ee68f384d29759d677dc182f8b9377bc7fddbbc4778998",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.iso9660.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.streams/0.16.13/discutils.streams.0.16.13.nupkg",
+    "sha512": "81fe953b957867ebd9922c55713d1700ee9857345df63c565ab8ba8a3253929fc111fcf477494b6a713f615465aa62f55b17f4f651baae20e59296fe4af27696",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.streams.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.udf/0.16.13/discutils.udf.0.16.13.nupkg",
+    "sha512": "cf8a49baae53e46515eabb53250e2d8d12956cffc61ce38c25abeafcde84b39b1d8e87b4ae9bcbb6293ac46e06743148bb312ed0f2ac649f1ce6c32c20fcfeb6",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.udf.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/dotnet.glob/3.1.3/dotnet.glob.3.1.3.nupkg",
+    "sha512": "9a3ffb310bf2a3383d869a6347c3578cc7c02318caeefcef73c4343d3b15592054f483840ea0d024e537edde6c63630ad5a90c5d8d3a41ef67f8033003dc3a92",
+    "dest": "nuget-sources",
+    "dest-filename": "dotnet.glob.3.1.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/excss/4.2.3/excss.4.2.3.nupkg",
+    "sha512": "fcb06d04937a6bd864060e8bdf4a65970c7450cdbdd3279465851310ac8bf12b645cac54ce8b7a8039c7ca9309ba3d9ee4e23827599479c4140f7755e119caa9",
+    "dest": "nuget-sources",
+    "dest-filename": "excss.4.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.3/harfbuzzsharp.7.3.0.3.nupkg",
+    "sha512": "bed625c58228c404f860fb3e247fb6ca3209c93fea62da498ba43419500bd40944b2e117f50f587f860101a6c6478ad1d18075f655376d1749d238d74b6a0bd3",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.3/harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg",
+    "sha512": "cf94e5693c4c475a702c342163f1ee28d2d9c3a13939a8334bb7133d13ffc5ed95d9dbb6145e7ac004cfd6e626a16280df7f1a4c7e3687569eced58b8890a1b5",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.3/harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg",
+    "sha512": "a6dac2eb2c536f25734e5358aaae9263f568871fa31169e816d8617c5b6e933d78e2956ea9e01ac37e0022bf243e63124956804b46f6a0d00826aa02320ef22b",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.3/harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg",
+    "sha512": "dd940d3b3085996b4e5961a0e42bb1a86daad360e3377602fafd60b0cb4d3d5ed9c3f4293a8551df75f38111b3a9f4dbbea4cb27b3e0632a6d48239b606d13c9",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.14.1/humanizer.core.2.14.1.nupkg",
+    "sha512": "cb3a8653f1ca34b67d52fafa92f49cdf0615fd2e4efc8be4948516e5617b32e8af18b63cc12e486672cf92dec3d4a5bc12dd849e5d08dcbce0daf196336e17b3",
+    "dest": "nuget-sources",
+    "dest-filename": "humanizer.core.2.14.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/icu4n/60.1.0-alpha.356/icu4n.60.1.0-alpha.356.nupkg",
+    "sha512": "f043fff5f139070ff84d2ec0397c2fb571ced6fcf37e2161f68406e9df03b86daa12fbe12a977f6e9f6f1a9bf46de5792d83fd82e4a2c395b3201aa2a846bc90",
+    "dest": "nuget-sources",
+    "dest-filename": "icu4n.60.1.0-alpha.356.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/icu4n.transliterator/60.1.0-alpha.356/icu4n.transliterator.60.1.0-alpha.356.nupkg",
+    "sha512": "1d6552fb8125793b391626ac930075b0db7903041e79bb43394cb75d767ff9c749c83099d73136366773a802ccf4b7537aff21e7c4b7f668e272511f7107af5c",
+    "dest": "nuget-sources",
+    "dest-filename": "icu4n.transliterator.60.1.0-alpha.356.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/idisposableanalyzers/4.0.8/idisposableanalyzers.4.0.8.nupkg",
+    "sha512": "86f93bc4c501c14cd4b0668bebacc54ec380a75ee12a3d973b4634acd230b6cde26743c617533a613005890d2d1a7271cec03ca167337376537dac63f755f07f",
+    "dest": "nuget-sources",
+    "dest-filename": "idisposableanalyzers.4.0.8.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/j2n/2.0.0/j2n.2.0.0.nupkg",
+    "sha512": "7b1fd8117c9608ec5a8502eb604760aaa81b3e490725b0d3fd055f2523053f2e6b9ddf15fb1101dff091949fe92da17a1130a2d295e328ee1a7a3e41a40833c4",
+    "dest": "nuget-sources",
+    "dest-filename": "j2n.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/jellyfin.xmltv/10.8.0/jellyfin.xmltv.10.8.0.nupkg",
+    "sha512": "b1ef253f878f7abb158268b78f29df7240998c63f4f1a94d60486c408abd8ec976b3572a1a0c1c1a149cb7ff4c6a048fc1ae9102c51b556aeddd7bed2e19e1d9",
+    "dest": "nuget-sources",
+    "dest-filename": "jellyfin.xmltv.10.8.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/libse/4.0.8/libse.4.0.8.nupkg",
+    "sha512": "2eb6eb3ae07d746fe8d19c9ae13d086e5f02483024a1accb5ad0e5162d894ff4cc24d430b42bffd75873a7eebe884bb6aa7ab351c4d1e77fea00e3840df9d352",
+    "dest": "nuget-sources",
+    "dest-filename": "libse.4.0.8.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/lrcparser/2024.728.2/lrcparser.2024.728.2.nupkg",
+    "sha512": "d1b27a7e33788e6b29f39a374962eb0ad9276524333cc526528bd53ffd35f14a95071667f6721925a12788b85c1bc458246f2ca76470af2bcd1811a0e4dc0c34",
+    "dest": "nuget-sources",
+    "dest-filename": "lrcparser.2024.728.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common/3.0.0/metabrainz.common.3.0.0.nupkg",
+    "sha512": "01350da82a7dc0ada18e726e15dff30e499491c0807a3fcb4cea5247c38a3c24d0afa34751e12b605cbd86143372e86e2f5b997cb08d1f42bb6dbfbcf67ddea3",
+    "dest": "nuget-sources",
+    "dest-filename": "metabrainz.common.3.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common.json/6.0.2/metabrainz.common.json.6.0.2.nupkg",
+    "sha512": "fa333a0227d1afe406960695b3c8ff8492112dd3a5e58027db63f84dfbd7122756e74af821f506c5137c08e3fa9c363177c3246375ce85acf358d35f961feb94",
+    "dest": "nuget-sources",
+    "dest-filename": "metabrainz.common.json.6.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.musicbrainz/6.1.0/metabrainz.musicbrainz.6.1.0.nupkg",
+    "sha512": "b36824dcbe668234e0974464122140717586b6d4ad881bc3e90d3bddca624f7982de3684e65f1571dd6cd3632e3c7edf6ac9de82a9c82b33a95df223541982e3",
+    "dest": "nuget-sources",
+    "dest-filename": "metabrainz.musicbrainz.6.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/8.0.11/microsoft.aspnetcore.app.runtime.linux-arm64.8.0.11.nupkg",
+    "sha512": "cfa9709633e91184bdd061951bf480e66da86175384e3a35ccc9ebbc768f207785807bc48628fd4101ecf6336a9495fbc9cb02aea3c0b9543c02e73fb96fb4f8",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.authorization/8.0.11/microsoft.aspnetcore.authorization.8.0.11.nupkg",
+    "sha512": "4f310a03a421ba8100430881ed34fedb75b10e3c6845bcf97cddc6927884e341778399b3bdee4c4fc1b4e5ea91a5f4cbe70da746d7f4efae092a71d41b97dd52",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.aspnetcore.authorization.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.metadata/8.0.11/microsoft.aspnetcore.metadata.8.0.11.nupkg",
+    "sha512": "d37a9d96f337e62d71c82ea63685553011039d2e940ca2b4f5690a15cabd4e0e84e1c66a59a5b429dfb221efc577937b6421b672a9e4e6ffdc69ea4bef0f9b61",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.aspnetcore.metadata.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/6.0.0/microsoft.bcl.asyncinterfaces.6.0.0.nupkg",
+    "sha512": "221a05a0c910f7a87b620d8f3831ed392b4eb95d112bee274d35f27009ad2a26445de9d7cd235fe6fb4a03f2550874bda3be3dddd96edaf9c0852a9c23d7b099",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.3/microsoft.codeanalysis.analyzers.3.3.3.nupkg",
+    "sha512": "0d4896db8aff9d731c5b1c8f73a4b37460c3f08080fbeac0ecf169abf5bdff9c9a994778f453816b888e939d9d0d615245c91a2e4ba31f85d2ea8de222767104",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.analyzers.3.3.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.bannedapianalyzers/3.3.4/microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg",
+    "sha512": "0b8e5e7aa98142864edd0073512f11c899f9b5aad535012726477cc1189de63252895a829c7ffc5730d09e5df8a6db7ccd9d0c6a17007bc94ca0ca5a36e04042",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/4.5.0/microsoft.codeanalysis.common.4.5.0.nupkg",
+    "sha512": "61f1aa2061217670fab3e1043e5068b72aed43907866195c693211407e2b3ebd6cd9762ed0b3e9ef06965a33d3ce3fb09c88f3c900ad32feb0485922575a41e3",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.common.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/4.5.0/microsoft.codeanalysis.csharp.4.5.0.nupkg",
+    "sha512": "68d7df26baf9362ec2cabb3543d1f7a570b0f345053a23e8feeb5317c50ba392825bafb1710ebee5c929e762e749782fd11eaadb3b437224ebfccba08b985fcf",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.csharp.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.workspaces/4.5.0/microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg",
+    "sha512": "474703fc47639e146aca623e2c15734c173167789e28bc2e46f65b8691d86c6db4e94723c469e2cea3ebd1f8395f816ad119350b91a88e95b6706db6ff977148",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.workspaces.common/4.5.0/microsoft.codeanalysis.workspaces.common.4.5.0.nupkg",
+    "sha512": "66f89952c90fac37702c0df2d04fbe8561768578baa0aa30a947220b253c952e109f4bb79c852bd471c16ad3957593db6a6e5e468994472f6210d742e6a4757f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.workspaces.common.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite/8.0.11/microsoft.data.sqlite.8.0.11.nupkg",
+    "sha512": "57374540586b0da9b6ae53ae4bea10faa84cc33850653366b4fd115783cadc8e4e999e8df9c54976a47a787dac6d71a44f527ed879a2182539ad80b64b445091",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.data.sqlite.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite.core/8.0.11/microsoft.data.sqlite.core.8.0.11.nupkg",
+    "sha512": "81efb4b0feaa97d67502645a4385d8c6a11e3b4e2bb1db3f2211ce2a7e9c703fd9f342126cdd328ff12dcf08be1cbd1478cc134bdf19da5237efc6dff46ab83d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.data.sqlite.core.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore/8.0.11/microsoft.entityframeworkcore.8.0.11.nupkg",
+    "sha512": "cf5d52c7f5d689cace47117d72ff5fef566fd8390006af8001df649bee0a3196ec381b00880db9b83926c5b8a559f7fd397dcb5db15c19e37b7a11bd04b91cd9",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.abstractions/8.0.11/microsoft.entityframeworkcore.abstractions.8.0.11.nupkg",
+    "sha512": "64080c34faacc6cd5831101c8b2245a58c3403ac0b1b5f6b4319ef3f5213673c606cedf541230c599714c49d19e88aba36bdbd4f6281e4db84d4f2c532d6afb7",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.abstractions.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.analyzers/8.0.11/microsoft.entityframeworkcore.analyzers.8.0.11.nupkg",
+    "sha512": "dfb27bfc753587d6f7c6c518bfc3743ed2ee1e35c048a9e0d2512b916f7f3ccc616248760bc780d7217097e3ee076048c24bb2e488b7722576438adff776a83f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.analyzers.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.design/8.0.11/microsoft.entityframeworkcore.design.8.0.11.nupkg",
+    "sha512": "2599c8a3081e8936ebdcea6f090c3611deadbbac48da95f84d922a9fd329d5399337752b2a1381240339f1656e43c4032619b70866dc58a2fbf835c2c2e9e255",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.design.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.relational/8.0.11/microsoft.entityframeworkcore.relational.8.0.11.nupkg",
+    "sha512": "6bf9071342ba151e8da4a28e9cbca2f4a15391c6d4d8e35e281224dfa7baa5b31bb5af34099d37ed3de92dec2aa98b8c80226b852a0fc794bc482ce106c70b1c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.relational.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite/8.0.11/microsoft.entityframeworkcore.sqlite.8.0.11.nupkg",
+    "sha512": "bd6cf8b7574693c262f9fa2c7cfdd59e4cf30999fb5bf6477151934a19dbfb21f94ecb8c9f1b1b9d1a3d3f6e70b541855d37f8c277ff30357edeedaef2dbfb18",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.sqlite.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite.core/8.0.11/microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg",
+    "sha512": "798a06456c660e67bc1e3a2c1049249fe2ce70d3317615ca353562220f7e7e8bff0db2e36b0f392e1e931765084dcd9229c6954c053a04f6b87ae9f2d1f88c75",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.tools/8.0.11/microsoft.entityframeworkcore.tools.8.0.11.nupkg",
+    "sha512": "1ad3b75bed1d444b631b344c9f0bc186d14863ecf8988233e52b53cc7e825e58fd61d5d6e38b2a623b3ee7a307d6f2900fec902a1c6aad0669ba3ea3391d0561",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.tools.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.apidescription.server/3.0.0/microsoft.extensions.apidescription.server.3.0.0.nupkg",
+    "sha512": "0935055d9b547f1feb24c9777a9d44dca03bb2218311d9b541103c724adb7a5b447ebf87b390dbcadb9380f05ffcacacb2fd3ad738f285cb25f70dcb24c6ab9b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.apidescription.server.3.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/2.0.0/microsoft.extensions.caching.abstractions.2.0.0.nupkg",
+    "sha512": "fc1f7d3f267d86ce18ba04aeebce36b4047f5a7c3cb2342a4209d3c0f1b0fa2f07ce70ea82a85442e9c9a54ec3102d63e5b88098a3f7c08468a835fb51fb423e",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.abstractions.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/8.0.0/microsoft.extensions.caching.abstractions.8.0.0.nupkg",
+    "sha512": "1fdc30912cc1ead9362f70853de219a9dc7070bc28f621e387185670e605746ee2f13b0df9db03d0b1f8919d4bdaad40ebe9f8203e3a0cbb61145aa8848be136",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/2.0.0/microsoft.extensions.caching.memory.2.0.0.nupkg",
+    "sha512": "2b46b6dca1b37f2b45c4001f7c52c5195fe2d488f32e2658bf025a1772c875a04555e84991385bf50d51536f6c2d53e16c8e23253da07a52f95d23e15f1a6bd3",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.memory.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/8.0.1/microsoft.extensions.caching.memory.8.0.1.nupkg",
+    "sha512": "39d053a5a92f413d012f910df6716cdac2f1cacfd234531b956dfcd10f1a83ea8cb84d017d4c72e011f87c53db27e33e9dc7c86f842eacdb1907cb895b448817",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.memory.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/3.1.0/microsoft.extensions.configuration.3.1.0.nupkg",
+    "sha512": "314056d5e02a6d57b1f2ad1b9c2c59d27a7326d88a08c5b938758a08162d49c9b227e89354ff4fbfa47d2679c5d1463e3eca489033cd5eaa38a71422fc757ecb",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/8.0.0/microsoft.extensions.configuration.8.0.0.nupkg",
+    "sha512": "da48a8ef3b4cd2a6beb78008382d9fccdcdd42ff3a71d9efc5ac69d4020421294ac95b07cf11520341a69ee241925cd040d49a382df243e2fa194f6896ef9734",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/3.1.0/microsoft.extensions.configuration.abstractions.3.1.0.nupkg",
+    "sha512": "13ebe935f71a5447ecf5729d177816dbc00b052ed8908c7371f62aef3510614031f6279e694d6ea3baed141c91645568c98290e9445d6278db2455e28136d1d6",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/8.0.0/microsoft.extensions.configuration.abstractions.8.0.0.nupkg",
+    "sha512": "3316170910a94290c8df4fed26fa884a47dd9bf974eb7ad22368d5a63308660a01d2dab4a44662061dacaeccf4ba09cdabfccd4636f76ab3178becec5ad31a2f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/3.1.0/microsoft.extensions.configuration.binder.3.1.0.nupkg",
+    "sha512": "965cc4ee738f92c9059492de62cb6984db69d420d825ffb13bf03793df481aea198a6f343d922807659f5ab07c4e9440ad079dbd78f5898cec25a59a90245a0c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.binder.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.0/microsoft.extensions.configuration.binder.8.0.0.nupkg",
+    "sha512": "9a5931e9d417b8cd4903fe8b94aa8ec07a1f0d43386717be38171a5eb432b1765d7da95e7f092e6997eccf3f4828d5716317a68fcc8fed32f0ad4f1f82bb7223",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.binder.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.2/microsoft.extensions.configuration.binder.8.0.2.nupkg",
+    "sha512": "63f5d5d0f5df1c7f90a138c75e14d81f3598af78c2c736a7aef5035ffcf9d40ac5a133571935a08290ceb92db72357c8203261165f8f7f057c450b2c611f6c2a",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.binder.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.environmentvariables/8.0.0/microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg",
+    "sha512": "e7e284b1af1362db2ae4ee6df9fff7b4766df63861837fed0019a43388f688158b328b45dc9188ec966bca8e0f1efae0eca9be739b41de24702001942e103db8",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.fileextensions/8.0.1/microsoft.extensions.configuration.fileextensions.8.0.1.nupkg",
+    "sha512": "a9727a08418460a2c66da8ed447cd9ca199157e43e22b84fb0d642cfc4b7b74cb577c3bbd7217b6abc3742fcba7b8e35f873a1a289ee4315c09ce5f1b94ee9a6",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.fileextensions.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.json/8.0.1/microsoft.extensions.configuration.json.8.0.1.nupkg",
+    "sha512": "b61e38d1accfadeae40c670f9414eb360987db39024d0619986733334a63a88aed9727ed8fbccd2fb906f1e37f3b3df8baf01c1cb819b72f452c559f02cab37c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.json.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/3.1.0/microsoft.extensions.dependencyinjection.3.1.0.nupkg",
+    "sha512": "d1f4b1f75870cba2faf333c7a7e8d3bedbce69424b06840957f3be2e95c13ff43e9bde14d48efb982656f31208997eacae9cb1ba2d54b3ad6d49264bad727cae",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.0/microsoft.extensions.dependencyinjection.8.0.0.nupkg",
+    "sha512": "96391af4ae0542f4ae96c8009c9ffbf304acadf476cda262a8ea73e33b172529541044186c59d656377bb2de42c9f5925e0632a81f6e7516f2a646e8916f16ec",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.1/microsoft.extensions.dependencyinjection.8.0.1.nupkg",
+    "sha512": "b6d2c496ce68bf91ac7499eb2a8aae34347e648b9be853e535a36044afcf8173561650aba33068346f458062f29c8e0c1f5859f73800d512ec0f464dd467d00f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/2.0.0/microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg",
+    "sha512": "54deb3578c6430a23120fe3c910cd789e64f59751e18bdccd6742f8170a6e38100be2d9e0b48188ff95dadf3dd7b8245dd33b2a4010d66fb895f5aa44c50207b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/3.1.0/microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg",
+    "sha512": "e184edffadaca3c7782695c8d291ebdabb42bd1b67a0764355c6ce9a186f8d186de36924288eab3978d07318f3aeb6f14e1a883d6f69f8e69a1948486a3ae577",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.0/microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg",
+    "sha512": "94bc05ed29755109565d9cdfc901087ee1fa08302dda393106bc9a0bd7384f0dc2b6c2f123c1bd53fce06babdbfa845dc6d22a163c4b0646c5251dcc5aeac282",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.2/microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg",
+    "sha512": "ba1960ef110ac7387a2a06eefc02c59ce57b0fe58b3e0cccb79b1c8f2150105c5d1f4b65e0ed95ff50d70f28142917c6a735b83f4e5406bb1d8f9dd1f9635d7d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/8.0.2/microsoft.extensions.dependencymodel.8.0.2.nupkg",
+    "sha512": "42a9e54c51b5f99a1d26ae79ce21accb5218a600b2534632aa2c2a4cdcac5d2942d2976f2c915fe8523ec5e390043607ac6b0a530de9e7cbbad9e1841ecea37e",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencymodel.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics/8.0.1/microsoft.extensions.diagnostics.8.0.1.nupkg",
+    "sha512": "a668c7de32c39384a0dcf85abb12560b2e286441ae269b39efea7149bb2e4a90a8949d6f941b9e24b8b3642f15f86b8a968f36183d97695019bd23f0ea7be237",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.0/microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg",
+    "sha512": "a75dd040e3e03e90c8baa006bd569db9fd09983cf9c27bfcb246d96a73e2595cea7aee6116438989f8df31b56bc7fe6adaa7a7fcb6ab95ec5b1d64d0b17ff617",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.1/microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg",
+    "sha512": "267c18ce804b572b17d9256b41c544428c5586c144a6815f864408f08ada786ec8ec239bb7a89d985571ad3e962fdc4a059511439db4936c0bdbd660bf002f46",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/8.0.11/microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg",
+    "sha512": "b93febd5e681c26766d890feb34d1062ce66d44b84d1103f8c1d4a80ed0964ded8ef2551fd6bcfeab1d95fd8c5922733448954bece46d96c781b9ae984a08ef5",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.abstractions/8.0.11/microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg",
+    "sha512": "0499640470c8390fee1a1fbc7a34efd4ef65f3ac93fe871420b6c844805e7711e6c98a9f3b1e9f1d8f598a247ef6d14e9dcdf3b442f31a65fd64a93ef3f64680",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore/8.0.11/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg",
+    "sha512": "962e83a815dd873648d722b9aa791298a6a6f1e82c11787f369babaa59fe45eef088f9556ec1e99a8ad9a18078339de3892dafbce4ed444d9e7a4d4e85135a7c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.abstractions/8.0.0/microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg",
+    "sha512": "fe9aa18f2e819694f20e322c93e075e27bee2d57ddd5380624fc48a95669c526c270ab5c74f58c6a4721d18ecdb5b2febf0315f8794585ae65617831459e2a0b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.physical/8.0.0/microsoft.extensions.fileproviders.physical.8.0.0.nupkg",
+    "sha512": "7612261a35b76d0b3a337ab262de57c3b605e8a1e55bf4d47f15e374e5577ab2ce4ae370980ef2c1335c4e323e6adcfe3718eee86570ac6e4ff5cb100450331f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.fileproviders.physical.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.filesystemglobbing/8.0.0/microsoft.extensions.filesystemglobbing.8.0.0.nupkg",
+    "sha512": "23a5e50cf695ba18c7a77f7c050e40d6fb065957480db17f5e75e5cf269c8f50763c996c28d0dcfca09e2c1248540898ab53c474cadc705548f5fe491dd263fd",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.filesystemglobbing.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.0/microsoft.extensions.hosting.abstractions.8.0.0.nupkg",
+    "sha512": "6788c16c139ba241cf2c65e4ded10b8ad8b38602b4490a5ff27dd52b02c90083b7cd40c7b4fac48aed94742f6545da959870b5d889b41078b22708acd761da66",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.1/microsoft.extensions.hosting.abstractions.8.0.1.nupkg",
+    "sha512": "4c7ef392ffc0c10a17b3bbc1232954fac16ed7e7e51aaaefd1e68f63eb19ca0b409f991bb72b4a1f9e7ecd241f196e579a2a740017cfe08b64c75062d60508e9",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/3.1.0/microsoft.extensions.http.3.1.0.nupkg",
+    "sha512": "7692b3ada00fff278826bede064e734889b0af77cc4a8f2865d40d2e7b437319b5f418abb1383717cc69aba94ea0c65de0c2683d52e3a10b788675e63bb72d21",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.http.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/8.0.1/microsoft.extensions.http.8.0.1.nupkg",
+    "sha512": "296bd0a65e3591df63d64e987c781c32fa677a08c84fe2911e6288eae94b1c77dd2a134692b5bfdcac93a4992fa14b69bbb81cfe3a1e7ff2e90d5babe917ec71",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.http.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/3.1.0/microsoft.extensions.logging.3.1.0.nupkg",
+    "sha512": "fd20e13f2908b212746f0b87df684bb3ca3599f40ceb72b7813be343b7dbef4d6865dd83c370d9ff719f88366f4998cefa481222e926db27dacc2493b610d415",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.8.0.0.nupkg",
+    "sha512": "aa30576c428dff69bac5f5d71721af6c4ef583bc524edbd0a94b49cbd80f698905021260e1a432c32e6d48ce5a30f6822c209f11dcf7c819aba1fa8347925b06",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.1/microsoft.extensions.logging.8.0.1.nupkg",
+    "sha512": "ab3363c4e103963ee5013ada55fddcd771961e48e5124f41e70589e589dacf27d20cff7e04bfc214db79fd937cbad80e99cef565f72e0cc10b84d9b3ac0619fd",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/3.1.0/microsoft.extensions.logging.abstractions.3.1.0.nupkg",
+    "sha512": "303b2749a54bbe683506e8981c39e3c3a9f76a08bc6eb9bd7ca7204079c6a88c68191a5247656e8c9138633be1a7758205b3bab92fca4a1e3a774b96315e6a63",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.abstractions.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.0/microsoft.extensions.logging.abstractions.8.0.0.nupkg",
+    "sha512": "50a0add96d30d90580fb8e02a25cea0aa15f4d22744279b5acfe18cc8568b74402aa062d5db13cc5887a08bfd24e07cbc88b2fc10ee8eec2c37edf3bcda7f8a7",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.2/microsoft.extensions.logging.abstractions.8.0.2.nupkg",
+    "sha512": "f8b9df3fa7b837cb5f2fa53a86bfd47279f81bc332db55b8bb7ea14f55dfe2158f351d35199c0cc0e01c735f394ded2a3a8f1c85c3ff6ea1c3ab785bfbf362fd",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.abstractions.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.objectpool/7.0.0/microsoft.extensions.objectpool.7.0.0.nupkg",
+    "sha512": "ee96a7f7ddda2557def993082c7d7429c25135b37b80df916f0427ee1349778722f10bd284810482662dee5c2f011fdb00e188626e7cde5c10c4b8718fef6639",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.objectpool.7.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/2.0.0/microsoft.extensions.options.2.0.0.nupkg",
+    "sha512": "afc8ef803afe1d832eb86f023bbbd5dc14b76583ce191338dfb2f7ff030adcec71d35aac194d4efcf0d08e5af572e2205e848fc137f8812f8ca85bde72e11e33",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/3.1.0/microsoft.extensions.options.3.1.0.nupkg",
+    "sha512": "643aac9c2d8d0aba135f9259d56d89a5d6b760723c694fd10a2ad3c8da291f535f27e94a733fbd7f80f208b1fd98ac6b5980c6546a3a1093eab40d7bfd617a9f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.0/microsoft.extensions.options.8.0.0.nupkg",
+    "sha512": "1c004082a132e7b75a0c95acef3578a4d5db42c55e0996e40b95b663e9a83c5a20ed481a85db7567fff7e3de3dbba6a7d4fe5c825dc7ce95de956689afa16c5a",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.2/microsoft.extensions.options.8.0.2.nupkg",
+    "sha512": "cc0c10336580c9519740a042b1e42d391bcb32b63732163ae1161e1c5b55a4cd4a736e1902eb2a4dbb89d784b0acf584b5042b4f3481a61dd30a4e229fb523c5",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/8.0.0/microsoft.extensions.options.configurationextensions.8.0.0.nupkg",
+    "sha512": "5c32ae67ae4e873216bbbec15554778e0acbebc283862a2debcb11a995c42a5fd75f9436c8da421aa51bc5c12db4e6c4e82f12da1ff942bc5a6e1a8cf3c77a7d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.configurationextensions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/2.0.0/microsoft.extensions.primitives.2.0.0.nupkg",
+    "sha512": "47284b149a0cb337dbbb5af3fe0ce8aaf3ab760b275f193407f3387ca8ec25d6fafc8dedd8c755ab8b35756b3c84e5ca8dcab6ea8bec2cbd543cba304ec69371",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.primitives.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/3.1.0/microsoft.extensions.primitives.3.1.0.nupkg",
+    "sha512": "abd8306bc481c1aa6ac016576e2be6be4332037af80dae407896727684e799d5147af2fff39a05f5be3e864391d5753897b7f35d8c57fc7221f5c4783e002ce5",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.primitives.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/8.0.0/microsoft.extensions.primitives.8.0.0.nupkg",
+    "sha512": "1f5475ca3d3ce18463456dd135afac502d6f82fea6e4e4814a61f86616c348decf28b73d15c2bb276d1a3c039ea6064f75e1329f6f3a64caa3520d70ab92c32d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.primitives.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/8.0.11/microsoft.netcore.app.host.linux-arm64.8.0.11.nupkg",
+    "sha512": "629914865afc8a5df3312571ffb43d64597b092df1fed720752236c005f2a0ac48c3a34e8f597b8a510176adaa2759cf6456e073925f4d425304c1ba6a14b3b0",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.app.host.linux-arm64.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/8.0.11/microsoft.netcore.app.runtime.linux-arm64.8.0.11.nupkg",
+    "sha512": "d40eb91197dc6c08c9e2cc72708fab91edec68d3225a0946e8d4f1859e53103461947cb897c16dfc63e7c287c5043e72f2c0ece476ecdf5f2ae5755ba6a10bd8",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
+    "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.1/microsoft.netcore.platforms.1.1.1.nupkg",
+    "sha512": "9835090f578b5c8ce6527582cd69663506460e9fdc5464fc2b287331c24d9369e57dd1543a865a8bd89d4fcfc569c26bf0dbfcce102675fdfd1479b9a9652819",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.platforms.1.1.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
+    "sha512": "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.platforms.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
+    "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.openapi/1.2.3/microsoft.openapi.1.2.3.nupkg",
+    "sha512": "9d8710a99c1a976014c0a4a837d021fa58fd13d5c1d573861e357c43ab1b4ea73ea85cf72afab0a3dfa5738908ade7ef6904e2d280ffff2ad9cfc8868c228461",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.openapi.1.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
+    "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
+    "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.win32.registry.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/8.0.0/microsoft.win32.systemevents.8.0.0.nupkg",
+    "sha512": "25016c508653fbf463c52d8fc3d2773b7c211c2402c4ea7b4aa987fb29c851d3f80c5e7abbcace2d4d5e061ae290524e8029afbc49a37d7e5186fe06aa4609b2",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.win32.systemevents.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/mimetypes/2.4.0/mimetypes.2.4.0.nupkg",
+    "sha512": "3d25e35d5e893dff932db404e2d9151be7da8e1cffe213d7689199dc81b337472e24fb6517db5fbb481f05676abd0b367f2e8ddc8b6a97af4dd6a273531e514e",
+    "dest": "nuget-sources",
+    "dest-filename": "mimetypes.2.4.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/mono.nat/3.0.4/mono.nat.3.0.4.nupkg",
+    "sha512": "b2909720dc40cd459741e4ad9af16cf8289dd43f5fe1f90a28f26937da8d8ec4621d3b296019a94bfe5c871ef12b41f49dc85c415e656d5376a3b1fa48d63973",
+    "dest": "nuget-sources",
+    "dest-filename": "mono.nat.3.0.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/mono.texttemplating/2.2.1/mono.texttemplating.2.2.1.nupkg",
+    "sha512": "22627ee103feee11c04c4eefb33b3ff874cd5553c71a4287266465b3bedf9803d27bb998ce736c9b977f79b436a168823a9d33637183ce466470c098187acb6f",
+    "dest": "nuget-sources",
+    "dest-filename": "mono.texttemplating.2.2.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/nebml/0.11.0/nebml.0.11.0.nupkg",
+    "sha512": "07dc3630b81d5e4a29be8df8178d6fba6f7bf20396bb5217af2941b741d88764e0a91e8d524249a9a94dbe8dfd5f128e4d8556e71404d63b521a493a8ccd9965",
+    "dest": "nuget-sources",
+    "dest-filename": "nebml.0.11.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
+    "sha512": "99b252bc77d1c5f5f7b51fd4ea7d5653e9961d7b3061cf9207f8643a9c7cc9965eebc84d6467f2989bb4723b1a244915cc232a78f894e8b748ca882a7c89fb92",
+    "dest": "nuget-sources",
+    "dest-filename": "newtonsoft.json.13.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/playlistsnet/1.4.1/playlistsnet.1.4.1.nupkg",
+    "sha512": "903c52d34062831b99a6d632f175e22e9afb247ae3618bfce8018b0595784264f0dbb0b63bf139d65dc8e34efdf15bce9e7608af1a8dee87765523193f85a850",
+    "dest": "nuget-sources",
+    "dest-filename": "playlistsnet.1.4.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/3.1.2/prometheus-net.3.1.2.nupkg",
+    "sha512": "140f9817fc9da297eeea6b7b6d03303d53364268bbda89cf76f56b37692c94c6fa160c2d0d475fc1d07857a64f21b0c7202178a5aaa0e64048254b6a0a439ad9",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.3.1.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/8.2.1/prometheus-net.8.2.1.nupkg",
+    "sha512": "f7094a591be84d1b8171081cc0c30e8ee4d2adb9118eb52fb53830f789de29960e86e17278dd44da439b5e463151fd7602dbf5bdab838c2b4626812b3d2a4ccc",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.8.2.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.aspnetcore/8.2.1/prometheus-net.aspnetcore.8.2.1.nupkg",
+    "sha512": "3ab7a9556aabfb429f87478b6e7e4eaed4445832189c670a245e8c77349946c6c2b278f30e6bfaa9ee9a5412789b300a70d96d5cf5d5f1b42b996f70e9660ffc",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.aspnetcore.8.2.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.dotnetruntime/4.4.1/prometheus-net.dotnetruntime.4.4.1.nupkg",
+    "sha512": "62712e2d734722927f6ee382dc4341efd0267549197dafa300e57692d40b46e7640d12c14452c0a9d298bc497b2831354fa531403ef64a0c8a187f1f98d951c5",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.dotnetruntime.4.4.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
+    "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
+    "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
+    "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
+    "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
+    "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
+    "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
+    "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
+    "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.0/runtime.any.system.runtime.4.3.0.nupkg",
+    "sha512": "bfee3c68312296860e5459af5e770c2e9fcd4ac134361fd569a9ce1e6574b9ae3978aad403f89639a4b5bac8ee5bb0ee1b8edb819e9a60f13ca5bd1812889bbd",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.runtime.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
+    "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
+    "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
+    "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
+    "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
+    "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "8f071552ee042f0cba39b1ba0a1205cf73de447d662995bae68f857a5946f7d154c029a79e37469081675687873c8bf2b9efe57f5cbd660c366b1ca51823f7f2",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "a135ca0f4f5a49319b5a52b7f4338f8a5fc4387edf26f29e6cbf63a3c3a37b2b5c51c9caf562ec41e470fba281060362465bc56915be782d6c75778aa6195e46",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "2f24e2cba88a96bb23848e1404878e4478a65642387b7b76aa4007587fe7c4d8208cbde53d3ed65f8d0d71cd688bfc16be66dc5f7bcf84c7b2ccf1b3c505b0b4",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
+    "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
+    "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+    "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.2/runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "a34ad2dbe67efcae97fcbea57af386b30660a98ab8229a56c0dca241316e673cf7a26e19c6efb6b7117cc271fdf208741ba6f8447ae254c91acba3ddb7d2923a",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "ce0873e07000df98e640bd265e969d4a9236535cee2699c5363f3ab297557b0d756260557995f2ee163cff05fc2ba922d66ba0e4cb28521f841e7d546ab3b63e",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "bf754c1a66cd70dc1bd38d54fe675e9dd470417ebba62e2f79e278be8f06cc3496ff58ed90d30b5dd4d3efea9accbd09eb17cd87be882951c0fdfb833c371f70",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+    "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "cd4b7ba744de80086521ab67cad2db3085d488388d3d9cb83d9946389f0f4c784539bf3a4ffb8d4f3347c5c7813aadef95b355fd2563e30c948a883c27b95287",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "d7fc28a9f600e471edce0989c01c485d4e2a7e99551f531413afa75039a4004d4e2c27e88976d65432635a321d86316a3c6cdaebc7b2fefa42141b64f4f10d66",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "5fe0e6a878eff59cfe24a8d57af51140576d8e0fec4988e4892c233c47b3a3eed27dec072a6c0d55dd615777cd9ce3fe545c5353b4a95289376ad0b9408ed4be",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
+    "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
+    "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
+    "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
+    "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.0/runtime.unix.system.private.uri.4.3.0.nupkg",
+    "sha512": "203ebe272791d79ab0c40afe9d0543852ee91b9fb4ae5bc15524d97728bc8bc9d7e0cbcf65d1fab8cfb0aa7a4ae37e7938933eef127aa5ea46f60e57b6ad2d91",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.private.uri.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.0/runtime.unix.system.runtime.extensions.4.3.0.nupkg",
+    "sha512": "54b81784c08e934389c59e6e155af6b1855e4bbc41678b01a702c94e6daba87c6ddfd16fe9e2cb61f3097bfa4950dbc37781454d027ce5ba6c50a393cc91b888",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.runtime.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog/3.1.1/serilog.3.1.1.nupkg",
+    "sha512": "02985d43db0efd5e56b086e0a29af986de381a163a8633ab81a88b6620a3df380afc4506366beba0f214ac8ec37c8d435bdf130285dcde331b14733e62fab8c7",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.3.1.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.0.0/serilog.4.0.0.nupkg",
+    "sha512": "1f6279bcfa93ca9c13180dd7c7e5944d5351358b9cd3a360cbbf12f2dda508700cb9ffadeffd4dfe772a6ddb2c029e2c3473e655a3b660a644de51d67133268c",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.4.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.1.0/serilog.4.1.0.nupkg",
+    "sha512": "4b0bcbc6ef35b4d1914dc870f3ecafc4a7e320b66842f8fce03d733874fd4d171885343c91e43dd1d5e49f55c50f948cf6c681c64819a8632187309ff82be15a",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.4.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.aspnetcore/8.0.3/serilog.aspnetcore.8.0.3.nupkg",
+    "sha512": "d46d53d19ea7c1c00eab3064fc995ca7d455df983355490d4053a5bb6e51164f74e007d4cdf1ed20de7c85b19bb65507f61645f2c3472cc386fe244230bd5f4a",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.aspnetcore.8.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.enrichers.thread/4.0.0/serilog.enrichers.thread.4.0.0.nupkg",
+    "sha512": "d776603c04a031634dfeb64203e3ed4204eb96d503ac8183d5ba231259c55cd4411359116164271e38ddb949a9c4604f4946021c52c34044cda85797e6b4a7c2",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.enrichers.thread.4.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.hosting/8.0.0/serilog.extensions.hosting.8.0.0.nupkg",
+    "sha512": "580cd1e3c1099bb8774504409e59cca246dc1e5754cc6a0e2085ca03c4ecaf66088e284d854c235578db3d0a449a854015454b686c0bbb1c299ac9c052e14a6d",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.extensions.hosting.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.logging/8.0.0/serilog.extensions.logging.8.0.0.nupkg",
+    "sha512": "cbe725d5313d4cbfe551ba20b6686ea02c17a6572b79170d312b3e31e3763b544276de387bfadd98bf623d602aabd5c6fcd131a2a29dbf7204c649a86d1cd8f1",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.extensions.logging.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.formatting.compact/2.0.0/serilog.formatting.compact.2.0.0.nupkg",
+    "sha512": "a4a87b075d4dea0f3d481669206a6488890e5f4e5615be587b9d4c74ff0b8bea260fa19e85610ef24ce2ce7af49cd561f4e2212769559352aac9325a234462ee",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.formatting.compact.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.settings.configuration/8.0.4/serilog.settings.configuration.8.0.4.nupkg",
+    "sha512": "04f71c87368908aa672326229cb5286cc14565124f539b2d19e4524a50bacbac9b4686c0cad52c8f0324e288f13620e0154a7b64d5abbd176a100b33ca32cc73",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.settings.configuration.8.0.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.async/2.1.0/serilog.sinks.async.2.1.0.nupkg",
+    "sha512": "04c6181f987cf459d96ffafca2a7cb7d5bef0f5b079277deb5ac009d238929ff8b075b2e73504330505462d76652ce106966dd3a0407c8799bfe5d0bec7f0fdd",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.async.2.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/6.0.0/serilog.sinks.console.6.0.0.nupkg",
+    "sha512": "49c6a20f42a9b46d8cccd76d287e92210aeb967d8f8daf93be82561fa050d91f927d0bb5ea81a147caa899b9abf47b616e5d74a8cfcffeadc1545da0b73a979c",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.console.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.debug/2.0.0/serilog.sinks.debug.2.0.0.nupkg",
+    "sha512": "fbddb39441be29aee4077c487e321ab0c3a167adc74f698115a5412d989e4d33c2a8d1cd9fcb96b312c567cb293d23f8431c936d9647691e019600a405c5cc6d",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.debug.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/6.0.0/serilog.sinks.file.6.0.0.nupkg",
+    "sha512": "90daa5403374597318b8973f4a7725dd14d44425a75793c82baa4143aeb3b4aeb8423636edd2b3b82a9df367d4e42339e73baaf62d42c87e7d4a958fa4394609",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.file.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.graylog/3.1.1/serilog.sinks.graylog.3.1.1.nupkg",
+    "sha512": "4509679ad467ca5c96344e08ed507684acce267d31865c3057bf1eed88fa2b66f9fd85d142669dc2fbc891ed82a04fc45d82aeb65d0ff2f4a4903fde37926470",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.graylog.3.1.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/seriloganalyzer/0.15.0/seriloganalyzer.0.15.0.nupkg",
+    "sha512": "c0ddb69f4e0ae258ceb8ce7ee6923b6aa6f815246a347684832fb7c08f9af696435a11986b73b2f9325138bd3da0932681127e166102f6a6b92943bd0c0e3e06",
+    "dest": "nuget-sources",
+    "dest-filename": "seriloganalyzer.0.15.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/2.0.0.1/shimskiasharp.2.0.0.1.nupkg",
+    "sha512": "babb41bfc0354dea0b52cc70ea9e9510204e33b0a8f544ceffacfaa919bc7ba26a24493ee70fb5a30758320380e4d88163a7daee0f663602db0365956eb7c0d1",
+    "dest": "nuget-sources",
+    "dest-filename": "shimskiasharp.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.9/skiasharp.2.88.9.nupkg",
+    "sha512": "3a2ffa5e05f45cdb80e6735ee947e91e08ff145fc50c7882e75d44b6ae0c2cd733420d15b6a4274a186b3a79d463a1273e27ff7fd79a51d0937251ebb6ef761d",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.9/skiasharp.harfbuzz.2.88.9.nupkg",
+    "sha512": "7ebc75df46b3d2bfb110324dc0613fb1395667219ce42c757fb98f0ff60b755fc69fe6bb94613a2be854e8feecdebe671ea46cd9e8a0df2e90ff7d461ab123cf",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.harfbuzz.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.9/skiasharp.nativeassets.linux.2.88.9.nupkg",
+    "sha512": "5c6a3e93a18e70e6adcd548bd2f76fa311114346ce4d812e520f250d33342d5ad8d05ea285433bd15cb19bbc48d9bbf2ef7d1f1725dd71705accefaba3f46892",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.nativeassets.linux.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.9/skiasharp.nativeassets.macos.2.88.9.nupkg",
+    "sha512": "74cfb865746f2911935290bfb92469b331e50415d5abeda87598ebdb4049c52af84a5daeda41ebcb0bbaec6a7debb42d83cdc6c9f61cea55d43c720a78c3ebce",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.nativeassets.macos.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.9/skiasharp.nativeassets.win32.2.88.9.nupkg",
+    "sha512": "d18bd8194041c7ffb79302d4f1be584e8c024e88b12cb4669a738cae551da3d3e3924087bb0aa42d34a9003cfb35037d73637894e67d02223d100a1b4215eeec",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.nativeassets.win32.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/smartanalyzers.multithreadinganalyzer/1.1.31/smartanalyzers.multithreadinganalyzer.1.1.31.nupkg",
+    "sha512": "0e703633c4e989fd218620ec76a21bbbd9dce34f313ea1dda8d698be11ffaf08d959b8e2d9c964aa661e7dff3611003504c757ce8cc956d8626fa2ab21c482fb",
+    "dest": "nuget-sources",
+    "dest-filename": "smartanalyzers.multithreadinganalyzer.1.1.31.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.bundle_e_sqlite3/2.1.6/sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg",
+    "sha512": "69169044def48e943aac624d83be72ae09b046b7f4bac1efcd2aebbe02fa9847ad8bc5303b05834b39880c05e33ce64a51a34f5887a13bbc35761d72ce086baf",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.core/2.1.6/sqlitepclraw.core.2.1.6.nupkg",
+    "sha512": "16bc39cd5325dea37e1564fc328a35966d6d820878290d945dc57496b716d4935b534285989af32fa7bd25ef9a8ac795b63e6a19044d3f84a104d643319473be",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.core.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.lib.e_sqlite3/2.1.6/sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg",
+    "sha512": "69543fcac6af6520b638ed00c5f8f8dc59747376382c561ca82904780214b3e75cc4293106c4a3f6f671b73d591195800c44afa2d4dc533a8257b00fdf77d663",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.provider.e_sqlite3/2.1.6/sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg",
+    "sha512": "527cec74f2ebeff238b3bb1f898637576659537aa6f2c5a4384b1c1b094cb772bfe86f05c13a1020247bd73fed8759c0bf568a1c0059c1d87bbbed2db1018701",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers/1.2.0-beta.556/stylecop.analyzers.1.2.0-beta.556.nupkg",
+    "sha512": "08163f6061ebc26ea9b8069a82e9f575d656a50f1d9299eda874f4107731eb2e02b512f201f1c34c6983d92baecd6ee5e992aa6b61c78ae9490a7fddbdd51882",
+    "dest": "nuget-sources",
+    "dest-filename": "stylecop.analyzers.1.2.0-beta.556.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers.unstable/1.2.0.556/stylecop.analyzers.unstable.1.2.0.556.nupkg",
+    "sha512": "0e9fbae713d2d30690bb331e7308a619894ee26c13798855ec0a2529b32468d67fbcf2bc1f02aa0f3ae7e6851d2b595684ef415245aa8119b9b1b7d58c30916b",
+    "dest": "nuget-sources",
+    "dest-filename": "stylecop.analyzers.unstable.1.2.0.556.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/2.0.0.1/svg.custom.2.0.0.1.nupkg",
+    "sha512": "0ccdaba6b38665c31d2e660a5983a980584a7ebb1a999d91cd3acfa3861f68a428a663f3fdf24093bed52f7628b9d2ea020a1ab6614d846c6c8a2515b90b2312",
+    "dest": "nuget-sources",
+    "dest-filename": "svg.custom.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/svg.model/2.0.0.1/svg.model.2.0.0.1.nupkg",
+    "sha512": "a02226f89e5c5ce81b49a1a38bda8945f070849fcc557fcf3ad2f500430c0e1410ee542681fc8b7a2d560c4bc00a084f58f96f001ded0ad94254d1e2d05fba67",
+    "dest": "nuget-sources",
+    "dest-filename": "svg.model.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/2.0.0.1/svg.skia.2.0.0.1.nupkg",
+    "sha512": "eec0ec97de78aca75af5aa5523df5afefdf7a9cdcea0379669d001a82b4fa3a3882a82614b4ab25c6436a48c9834d3d1e19e669fe32d1396d4c8bb6c712a94ad",
+    "dest": "nuget-sources",
+    "dest-filename": "svg.skia.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore/6.2.3/swashbuckle.aspnetcore.6.2.3.nupkg",
+    "sha512": "3e491d5f00e2ea8c26170ed72c0ab670beb3d8178baff82a4aa8e97986791f65125c62a73e413d5d6b435ca2205e2bbe92d6e542a504a7ad2cce552eb3548f93",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.redoc/6.5.0/swashbuckle.aspnetcore.redoc.6.5.0.nupkg",
+    "sha512": "0a2d7427dd148741e5761818cf9a920b198fa235304abc00310b56dbb94147734adbadd7c0a3fcfcc32b1443609b248842e8611849c0a3f56419a4b3007f1488",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.redoc.6.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swagger/6.2.3/swashbuckle.aspnetcore.swagger.6.2.3.nupkg",
+    "sha512": "c12fd032b76e9cbc4697b3bae1f123807410e3d5a8eaf3558a1840880f8bd30fa5dc4b316e86575310eb6eec1924467e0c9c02631afb10e20ec9eead6da3f439",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.swagger.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggergen/6.2.3/swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg",
+    "sha512": "777f7ac29a52dd45bdcbc4a2f426e12f5f8918b9d7e018b4cb8c8f26cb2f40bec77378c9cff23a951170559a9ef4b24a25ab2a3a2ddff63a30cec9240e535912",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggerui/6.2.3/swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg",
+    "sha512": "90e6aafa82fbdcacba8b48a2f59bcb6418a5ecab7e7d659b44ce8d8bc5a3aa97ee168e85a971e8d4cc5d78e3e1f9e2a5cd0e9e4da09cd8d32f898eca4f74b397",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
+    "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
+    "dest": "nuget-sources",
+    "dest-filename": "system.buffers.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.codedom/4.4.0/system.codedom.4.4.0.nupkg",
+    "sha512": "13f96f49f3053ed35f94081d33a02e3d4f096d976a752a06a54eba1bb4ab76e0aa76b1723df95aaaa57880dd9dd21ac2069bbdd876a8aa950fe5dfa0f48b5cc7",
+    "dest": "nuget-sources",
+    "dest-filename": "system.codedom.4.4.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
+    "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
+    "dest": "nuget-sources",
+    "dest-filename": "system.collections.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
+    "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
+    "dest": "nuget-sources",
+    "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/6.0.0/system.collections.immutable.6.0.0.nupkg",
+    "sha512": "f8036412e384c5c5af6d28f4eab2543207d2ebbb16c47b70f6c471bc5aa4b9f44404c47d776d295191f20a89caa898abd73a2304dcaf77979174ced2d9160169",
+    "dest": "nuget-sources",
+    "dest-filename": "system.collections.immutable.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition/6.0.0/system.composition.6.0.0.nupkg",
+    "sha512": "48618297e7fcf02b05bce032bcde1882be780e0e6d156b8312855f2a2d080ff590fd7bcc7a296ebddec9d82f654d9286e42b424ce07b112a449be2bfb29bcb8c",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.attributedmodel/6.0.0/system.composition.attributedmodel.6.0.0.nupkg",
+    "sha512": "a53c30b3cfeb4fc67741e85305707b324481a6ac394fb1af71acda01309c090557424a4352135effe0dc37c2953634441994328d89c22532d8fdf8eb7f717405",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.attributedmodel.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.convention/6.0.0/system.composition.convention.6.0.0.nupkg",
+    "sha512": "f4dd753fa196325d1a5e9a06874e88d9651f812f48b013608efe322e079ba194bdf4587603bcd71a86e33f53103c48b1dc8f1776842d5dfb4afbd7e8b4e9dd02",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.convention.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.hosting/6.0.0/system.composition.hosting.6.0.0.nupkg",
+    "sha512": "5a5a331c91f12b6cb63c5dfbea1095980a0a0bfa5d9e336c7316245706f6bedafd76a0b6880ca2c79415f31840c231730285b9bcc3b9474659a28ac9fdabd03b",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.hosting.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.runtime/6.0.0/system.composition.runtime.6.0.0.nupkg",
+    "sha512": "ccf6d0fa4a8bb6a170121281728e965df4d346a69c55e0ecefab6b8241959876de568462b7d5dbd290aa6e510cbf1973802466e99b59a7e95b92889052acd79f",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.runtime.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.typedparts/6.0.0/system.composition.typedparts.6.0.0.nupkg",
+    "sha512": "8cf43d8d159dc065c04ad9ec09a60ff431a2fe5fb3d4821c04a02a11687ede9bbc900d82f6d4d6f5d298895c664afbe0e6982b63a20059c5884bdb8c265793b7",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.typedparts.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
+    "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
+    "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/8.0.0/system.diagnostics.diagnosticsource.8.0.0.nupkg",
+    "sha512": "86e32c62e9773dba192a63bff0e2ffcd57826ed1123c9261fa8c9229f9d1dc26962b3740fb025f6ad5c139162575a6c493b213a9ef3fc1747d15ca0edd0c5878",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.diagnosticsource.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
+    "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/8.0.8/system.drawing.common.8.0.8.nupkg",
+    "sha512": "318e393b68d144d12d3a41de0dbdaba6796c7be03bb70ead38b5ee7f5581fe059ce78fb39cf4d8e45f1c8ecd194a4b38ff20fd034beeb79a56bfd6a8e33eab52",
+    "dest": "nuget-sources",
+    "dest-filename": "system.drawing.common.8.0.8.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
+    "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
+    "dest": "nuget-sources",
+    "dest-filename": "system.globalization.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
+    "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
+    "dest": "nuget-sources",
+    "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
+    "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
+    "dest": "nuget-sources",
+    "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
+    "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
+    "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.filesystem.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
+    "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.3/system.io.pipelines.6.0.3.nupkg",
+    "sha512": "a72246cbe26c5a7ec098f69798063076731529a3b2e555a3d41692ef5496222328d3988cfbd8e23a54e474f5429df3e478537f85e0dbc145d2cf3c263dbe726e",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.pipelines.6.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
+    "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
+    "dest": "nuget-sources",
+    "dest-filename": "system.linq.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.linq.async/6.0.1/system.linq.async.6.0.1.nupkg",
+    "sha512": "792b7b14a6fcc52f88cc0475a2ba8a694399393fa602446fe23fa6d39d782c16f908b4bc3acd58454554932b7a41056d84424b5fd66f0fe6e3c00178eb3d8a1a",
+    "dest": "nuget-sources",
+    "dest-filename": "system.linq.async.6.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
+    "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
+    "dest": "nuget-sources",
+    "dest-filename": "system.memory.4.5.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.4/system.net.http.4.3.4.nupkg",
+    "sha512": "163edeef734d1f0a1ff7b8053d326eabc82fe86f3de72c6466dd780d59d974487882f2a5f16ae4b02c0d8c8a7f25e617ff2bbfab133f88ebfd6a2f99637169ed",
+    "dest": "nuget-sources",
+    "dest-filename": "system.net.http.4.3.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
+    "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
+    "dest": "nuget-sources",
+    "dest-filename": "system.net.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.0/system.private.uri.4.3.0.nupkg",
+    "sha512": "5989a57ef273b689a663e961a0fe09d9b1d88438e5478358efc4b165de3b2674fa9579c301ce12d2d2fa5f33295f2acb42eceea2ebebf70c733da6364ceaf94d",
+    "dest": "nuget-sources",
+    "dest-filename": "system.private.uri.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
+    "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
+    "dest": "nuget-sources",
+    "dest-filename": "system.reflection.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/6.0.1/system.reflection.metadata.6.0.1.nupkg",
+    "sha512": "7ae13917018aee2c9074db134aaa27cad2d71072f7d80bb13dc16b1de16cec62503b064914d12d86326534c9ed29dbbaed5fcdab7f88b620ae1d1c5022b4673b",
+    "dest": "nuget-sources",
+    "dest-filename": "system.reflection.metadata.6.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
+    "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
+    "dest": "nuget-sources",
+    "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
+    "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
+    "dest": "nuget-sources",
+    "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
+    "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.4.0/system.runtime.compilerservices.unsafe.4.4.0.nupkg",
+    "sha512": "d03f39b62f48714c56aa5db5ddde1613e7f62633734731e611a1b7e2a880de10fb1bc3b88b4320afe46eb649f8a66adbad6f80058e2fce910280799dc3ebd38d",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.compilerservices.unsafe.4.4.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
+    "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
+    "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg",
+    "sha512": "0a5baf1dd554bf9e01bcb4ce082cb26ee82b783364feb47cba730faeecd70edc528efad0394dcce11f37d7f9507f8608f15629ebaf051906bfd3513e46af0f11",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.handles.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
+    "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
+    "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/5.0.0/system.security.accesscontrol.5.0.0.nupkg",
+    "sha512": "ae6b03ad029d3eb6818a6c8bb56cf4904013fa535a67b8e621b783a029dd88aa2e471e002cbc7d720381ad8bc8c6b93111a08f6ce2d271af6d974bf4d02b6c81",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.accesscontrol.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
+    "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
+    "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
+    "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
+    "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
+    "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
+    "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
+    "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/5.0.0/system.security.principal.windows.5.0.0.nupkg",
+    "sha512": "44a920aaaf22b2172d41319bb57ab2b8e1a4531d5f02192a6f53a81d875125195b60ba0b5a44a45981d137fd7b0f3a65b12959b5fd97afc0578cd84ef27467cd",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.principal.windows.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg",
+    "sha512": "6ff7feec7313a7121f795ec7d376e4b8728c17294219fafdfd4ea078f9df1455b4685f0b3962c3810098e95d68594a8392c0b799d36ec8284cd6fcbd4cfe2c67",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/6.0.0/system.text.encoding.codepages.6.0.0.nupkg",
+    "sha512": "ec873a95ec517de2c5a5364ada30974ddd5e0fafef2ad2517609a1900b5059d35757536fd073805001fa68d5b56a3d4647010a96c9eb233b1d172a3b45fbe4a9",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.codepages.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.8.0.0.nupkg",
+    "sha512": "77dadf6b1a73eeefb50507a6d76f5e3a20e0ae7d3f550c349265ae4e0d55f0ae4f0ef1b41be08dd810798a8e01dbba74e2caac746b5158b8e23d722523d473ed",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.codepages.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
+    "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/8.0.5/system.text.json.8.0.5.nupkg",
+    "sha512": "13589021ae3e81f54c877abf613ce931cc24ca57bf127af1063ccc1eb4dc57a6cc223a61e6452207f5d0dce453b6627430e31e4143c78e71e9b5dd647f680abf",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.json.8.0.5.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg",
+    "sha512": "97a2751bdce69faaf9c54f834a9fd5c60c7a786faa52f420769828dbc9b5804c1f3721ba1ea945ea1d844835d909810f9e782c9a44d0faaecccb230c4cd95a88",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading.channels/6.0.0/system.threading.channels.6.0.0.nupkg",
+    "sha512": "32adff895c57ab9ef864cf89660403f041b07841be7c44a0c3c2c8451a1da076a8c1b4dcf1c993b585304ad7549afa408a0f797ad6814d0f14eb748a1fc9ce03",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.channels.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg",
+    "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.tasks.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/8.0.1/system.threading.tasks.dataflow.8.0.1.nupkg",
+    "sha512": "24622fd7d5e33cb55309d0dd35616aa3d6e7aa0c66e1e597c0ca6106cb26cc4248349815139c8f00a51e062506f5fa5f6cffeaa6fe8cb030c64b1d6952224ab1",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.tasks.dataflow.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/taglibsharp/2.3.0/taglibsharp.2.3.0.nupkg",
+    "sha512": "9be37f6431f6ead36babe78dc6527340d7b4b0fe444736aaeae5aef3651191d4e0421d9d671106aea544888695d7841000fb12f8a44aab1b5fe93fb7c90d983f",
+    "dest": "nuget-sources",
+    "dest-filename": "taglibsharp.2.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/tmdblib/2.2.0/tmdblib.2.2.0.nupkg",
+    "sha512": "ad0cb6ad203d1ce0f0f2f9f96140326abc0fc54e7b79e38846f6d3431e5c0f17bbe689cd52059931f52f258b16a2ce55fb9f7b2c7ca6b800542fcaf257a2774f",
+    "dest": "nuget-sources",
+    "dest-filename": "tmdblib.2.2.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/ude.netstandard/1.2.0/ude.netstandard.1.2.0.nupkg",
+    "sha512": "29c5e5a43cd2a0a9dc770ac3ec9976c5ef922622d114bb12cfde950f58d45fbd385e013d170df6fa2d45f9c56d29738bb4240b4f1c3a0e3908d9f99ff938c3c0",
+    "dest": "nuget-sources",
+    "dest-filename": "ude.netstandard.1.2.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/utf.unknown/2.5.1/utf.unknown.2.5.1.nupkg",
+    "sha512": "342b4a01af4cfb0a0b77de0afd7c6393fafc124e72b420ff1f7936891aa259e6a55129d46e54eb5d7fce9759a6ab52ebec89045fcffb23148324ebaa7b604629",
+    "dest": "nuget-sources",
+    "dest-filename": "utf.unknown.2.5.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/z440.atl.core/6.8.0/z440.atl.core.6.8.0.nupkg",
+    "sha512": "e52cd9acbe0eba1c72c6d2967a314198421e029ca0271e4872f37044549173d3403f33e2d391350356c96772938d1fa95ba9c914b238b3929d3c9293469c3fd5",
+    "dest": "nuget-sources",
+    "dest-filename": "z440.atl.core.6.8.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/zlib.net-mutliplatform/1.0.8/zlib.net-mutliplatform.1.0.8.nupkg",
+    "sha512": "c329dc559df3eb4b4bf2f832f37442af6d1be625c97a904f25bc4078684e4716d769ee2c1215329e78a299ec0f6c8a90d6ed1e3116162433f490a7bb54d30b52",
+    "dest": "nuget-sources",
+    "dest-filename": "zlib.net-mutliplatform.1.0.8.nupkg"
+  }
 ]

--- a/nuget-generated-sources-x64.json
+++ b/nuget-generated-sources-x64.json
@@ -1,1766 +1,1766 @@
 [
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/asynckeyedlock/7.0.2/asynckeyedlock.7.0.2.nupkg",
-        "sha512": "3531c49506ca4166791bc4a394d00690c35c52a5ffa1f0946bc02cf9ead793f82f933a6c90ec85ddd67e97723ca56da998cf3a586cbb75db1fe39bbe64b479c7",
-        "dest": "nuget-sources",
-        "dest-filename": "asynckeyedlock.7.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/bdinfo/0.8.0/bdinfo.0.8.0.nupkg",
-        "sha512": "b9b3e42e71def59d5150ad4a830f8792b39bfd1964a5c975e509fcd47569cbaaae763da098346f852f90dcd5c82bf9136d3130819d12c1452b2b9f21cad14367",
-        "dest": "nuget-sources",
-        "dest-filename": "bdinfo.0.8.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp/1.3.3/blurhashsharp.1.3.3.nupkg",
-        "sha512": "7a49ff313da159a1aefc91279c77eb7265a52c50118e4b91d2174a225edfaec13051cc49023fdc4c08ce52635bd68d88e1de9c5968d885fc0d5e53934ea96c17",
-        "dest": "nuget-sources",
-        "dest-filename": "blurhashsharp.1.3.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp.skiasharp/1.3.3/blurhashsharp.skiasharp.1.3.3.nupkg",
-        "sha512": "f17106411b69a58580e0854a662d44623445e96866d6cf8834865ff978dd1f08ab5646632f35799ed53f56d13d5624efa0e44f60bf10b116c0459c41bc9b2fad",
-        "dest": "nuget-sources",
-        "dest-filename": "blurhashsharp.skiasharp.1.3.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.9.1/commandlineparser.2.9.1.nupkg",
-        "sha512": "4f364e45c9668c7e7cc6a922b488f3fa523033c20d7a432694f0a6af05ce528ea0481d8375e2f4f1032c6990347b4803ce9a0e48068c6fe15ec46fb1254f085d",
-        "dest": "nuget-sources",
-        "dest-filename": "commandlineparser.2.9.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/diacritics/3.3.29/diacritics.3.3.29.nupkg",
-        "sha512": "48d53debccd23a0cea558199f19e26313db0d56f5e65cd9b5866b2c4bc9ccd2273088be9528eba504b43aefdcbc44f2fa54ae175e2c8e5fcbec04fef92be5382",
-        "dest": "nuget-sources",
-        "dest-filename": "diacritics.3.3.29.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.core/0.16.13/discutils.core.0.16.13.nupkg",
-        "sha512": "637e7448e43b8f022858b88073b9a10a937af6878846734ca19eee56af7d0f66a09aec007948eb50b16fc09c78b5526c38773487e956d906566d66459551c47b",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.core.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.iso9660/0.16.13/discutils.iso9660.0.16.13.nupkg",
-        "sha512": "6c9e2c62e2e25c119da650d5991375618f61d7935856a19ddef1f5626ccdff7ada3b32443e03272cf1ee68f384d29759d677dc182f8b9377bc7fddbbc4778998",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.iso9660.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.streams/0.16.13/discutils.streams.0.16.13.nupkg",
-        "sha512": "81fe953b957867ebd9922c55713d1700ee9857345df63c565ab8ba8a3253929fc111fcf477494b6a713f615465aa62f55b17f4f651baae20e59296fe4af27696",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.streams.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/discutils.udf/0.16.13/discutils.udf.0.16.13.nupkg",
-        "sha512": "cf8a49baae53e46515eabb53250e2d8d12956cffc61ce38c25abeafcde84b39b1d8e87b4ae9bcbb6293ac46e06743148bb312ed0f2ac649f1ce6c32c20fcfeb6",
-        "dest": "nuget-sources",
-        "dest-filename": "discutils.udf.0.16.13.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/dotnet.glob/3.1.3/dotnet.glob.3.1.3.nupkg",
-        "sha512": "9a3ffb310bf2a3383d869a6347c3578cc7c02318caeefcef73c4343d3b15592054f483840ea0d024e537edde6c63630ad5a90c5d8d3a41ef67f8033003dc3a92",
-        "dest": "nuget-sources",
-        "dest-filename": "dotnet.glob.3.1.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/excss/4.2.3/excss.4.2.3.nupkg",
-        "sha512": "fcb06d04937a6bd864060e8bdf4a65970c7450cdbdd3279465851310ac8bf12b645cac54ce8b7a8039c7ca9309ba3d9ee4e23827599479c4140f7755e119caa9",
-        "dest": "nuget-sources",
-        "dest-filename": "excss.4.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.3/harfbuzzsharp.7.3.0.3.nupkg",
-        "sha512": "bed625c58228c404f860fb3e247fb6ca3209c93fea62da498ba43419500bd40944b2e117f50f587f860101a6c6478ad1d18075f655376d1749d238d74b6a0bd3",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.3/harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg",
-        "sha512": "cf94e5693c4c475a702c342163f1ee28d2d9c3a13939a8334bb7133d13ffc5ed95d9dbb6145e7ac004cfd6e626a16280df7f1a4c7e3687569eced58b8890a1b5",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.3/harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg",
-        "sha512": "a6dac2eb2c536f25734e5358aaae9263f568871fa31169e816d8617c5b6e933d78e2956ea9e01ac37e0022bf243e63124956804b46f6a0d00826aa02320ef22b",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.3/harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg",
-        "sha512": "dd940d3b3085996b4e5961a0e42bb1a86daad360e3377602fafd60b0cb4d3d5ed9c3f4293a8551df75f38111b3a9f4dbbea4cb27b3e0632a6d48239b606d13c9",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.14.1/humanizer.core.2.14.1.nupkg",
-        "sha512": "cb3a8653f1ca34b67d52fafa92f49cdf0615fd2e4efc8be4948516e5617b32e8af18b63cc12e486672cf92dec3d4a5bc12dd849e5d08dcbce0daf196336e17b3",
-        "dest": "nuget-sources",
-        "dest-filename": "humanizer.core.2.14.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/icu4n/60.1.0-alpha.356/icu4n.60.1.0-alpha.356.nupkg",
-        "sha512": "f043fff5f139070ff84d2ec0397c2fb571ced6fcf37e2161f68406e9df03b86daa12fbe12a977f6e9f6f1a9bf46de5792d83fd82e4a2c395b3201aa2a846bc90",
-        "dest": "nuget-sources",
-        "dest-filename": "icu4n.60.1.0-alpha.356.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/icu4n.transliterator/60.1.0-alpha.356/icu4n.transliterator.60.1.0-alpha.356.nupkg",
-        "sha512": "1d6552fb8125793b391626ac930075b0db7903041e79bb43394cb75d767ff9c749c83099d73136366773a802ccf4b7537aff21e7c4b7f668e272511f7107af5c",
-        "dest": "nuget-sources",
-        "dest-filename": "icu4n.transliterator.60.1.0-alpha.356.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/idisposableanalyzers/4.0.8/idisposableanalyzers.4.0.8.nupkg",
-        "sha512": "86f93bc4c501c14cd4b0668bebacc54ec380a75ee12a3d973b4634acd230b6cde26743c617533a613005890d2d1a7271cec03ca167337376537dac63f755f07f",
-        "dest": "nuget-sources",
-        "dest-filename": "idisposableanalyzers.4.0.8.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/j2n/2.0.0/j2n.2.0.0.nupkg",
-        "sha512": "7b1fd8117c9608ec5a8502eb604760aaa81b3e490725b0d3fd055f2523053f2e6b9ddf15fb1101dff091949fe92da17a1130a2d295e328ee1a7a3e41a40833c4",
-        "dest": "nuget-sources",
-        "dest-filename": "j2n.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/jellyfin.xmltv/10.8.0/jellyfin.xmltv.10.8.0.nupkg",
-        "sha512": "b1ef253f878f7abb158268b78f29df7240998c63f4f1a94d60486c408abd8ec976b3572a1a0c1c1a149cb7ff4c6a048fc1ae9102c51b556aeddd7bed2e19e1d9",
-        "dest": "nuget-sources",
-        "dest-filename": "jellyfin.xmltv.10.8.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/libse/4.0.8/libse.4.0.8.nupkg",
-        "sha512": "2eb6eb3ae07d746fe8d19c9ae13d086e5f02483024a1accb5ad0e5162d894ff4cc24d430b42bffd75873a7eebe884bb6aa7ab351c4d1e77fea00e3840df9d352",
-        "dest": "nuget-sources",
-        "dest-filename": "libse.4.0.8.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/lrcparser/2024.728.2/lrcparser.2024.728.2.nupkg",
-        "sha512": "d1b27a7e33788e6b29f39a374962eb0ad9276524333cc526528bd53ffd35f14a95071667f6721925a12788b85c1bc458246f2ca76470af2bcd1811a0e4dc0c34",
-        "dest": "nuget-sources",
-        "dest-filename": "lrcparser.2024.728.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common/3.0.0/metabrainz.common.3.0.0.nupkg",
-        "sha512": "01350da82a7dc0ada18e726e15dff30e499491c0807a3fcb4cea5247c38a3c24d0afa34751e12b605cbd86143372e86e2f5b997cb08d1f42bb6dbfbcf67ddea3",
-        "dest": "nuget-sources",
-        "dest-filename": "metabrainz.common.3.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common.json/6.0.2/metabrainz.common.json.6.0.2.nupkg",
-        "sha512": "fa333a0227d1afe406960695b3c8ff8492112dd3a5e58027db63f84dfbd7122756e74af821f506c5137c08e3fa9c363177c3246375ce85acf358d35f961feb94",
-        "dest": "nuget-sources",
-        "dest-filename": "metabrainz.common.json.6.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.musicbrainz/6.1.0/metabrainz.musicbrainz.6.1.0.nupkg",
-        "sha512": "b36824dcbe668234e0974464122140717586b6d4ad881bc3e90d3bddca624f7982de3684e65f1571dd6cd3632e3c7edf6ac9de82a9c82b33a95df223541982e3",
-        "dest": "nuget-sources",
-        "dest-filename": "metabrainz.musicbrainz.6.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.11/microsoft.aspnetcore.app.runtime.linux-x64.8.0.11.nupkg",
-        "sha512": "5373c5f77dc775544b72d4994101cac0618ca885518a44b928cd888086f9287f73a17af3642a6b017242beb6500e83ad68a3a7f9ebb217e832ebd0af781fa03b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.authorization/8.0.11/microsoft.aspnetcore.authorization.8.0.11.nupkg",
-        "sha512": "4f310a03a421ba8100430881ed34fedb75b10e3c6845bcf97cddc6927884e341778399b3bdee4c4fc1b4e5ea91a5f4cbe70da746d7f4efae092a71d41b97dd52",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.authorization.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.metadata/8.0.11/microsoft.aspnetcore.metadata.8.0.11.nupkg",
-        "sha512": "d37a9d96f337e62d71c82ea63685553011039d2e940ca2b4f5690a15cabd4e0e84e1c66a59a5b429dfb221efc577937b6421b672a9e4e6ffdc69ea4bef0f9b61",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.metadata.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/6.0.0/microsoft.bcl.asyncinterfaces.6.0.0.nupkg",
-        "sha512": "221a05a0c910f7a87b620d8f3831ed392b4eb95d112bee274d35f27009ad2a26445de9d7cd235fe6fb4a03f2550874bda3be3dddd96edaf9c0852a9c23d7b099",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.3/microsoft.codeanalysis.analyzers.3.3.3.nupkg",
-        "sha512": "0d4896db8aff9d731c5b1c8f73a4b37460c3f08080fbeac0ecf169abf5bdff9c9a994778f453816b888e939d9d0d615245c91a2e4ba31f85d2ea8de222767104",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.analyzers.3.3.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.bannedapianalyzers/3.3.4/microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg",
-        "sha512": "0b8e5e7aa98142864edd0073512f11c899f9b5aad535012726477cc1189de63252895a829c7ffc5730d09e5df8a6db7ccd9d0c6a17007bc94ca0ca5a36e04042",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/4.5.0/microsoft.codeanalysis.common.4.5.0.nupkg",
-        "sha512": "61f1aa2061217670fab3e1043e5068b72aed43907866195c693211407e2b3ebd6cd9762ed0b3e9ef06965a33d3ce3fb09c88f3c900ad32feb0485922575a41e3",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/4.5.0/microsoft.codeanalysis.csharp.4.5.0.nupkg",
-        "sha512": "68d7df26baf9362ec2cabb3543d1f7a570b0f345053a23e8feeb5317c50ba392825bafb1710ebee5c929e762e749782fd11eaadb3b437224ebfccba08b985fcf",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.workspaces/4.5.0/microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg",
-        "sha512": "474703fc47639e146aca623e2c15734c173167789e28bc2e46f65b8691d86c6db4e94723c469e2cea3ebd1f8395f816ad119350b91a88e95b6706db6ff977148",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.workspaces.common/4.5.0/microsoft.codeanalysis.workspaces.common.4.5.0.nupkg",
-        "sha512": "66f89952c90fac37702c0df2d04fbe8561768578baa0aa30a947220b253c952e109f4bb79c852bd471c16ad3957593db6a6e5e468994472f6210d742e6a4757f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.workspaces.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite/8.0.11/microsoft.data.sqlite.8.0.11.nupkg",
-        "sha512": "57374540586b0da9b6ae53ae4bea10faa84cc33850653366b4fd115783cadc8e4e999e8df9c54976a47a787dac6d71a44f527ed879a2182539ad80b64b445091",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.data.sqlite.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite.core/8.0.11/microsoft.data.sqlite.core.8.0.11.nupkg",
-        "sha512": "81efb4b0feaa97d67502645a4385d8c6a11e3b4e2bb1db3f2211ce2a7e9c703fd9f342126cdd328ff12dcf08be1cbd1478cc134bdf19da5237efc6dff46ab83d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.data.sqlite.core.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore/8.0.11/microsoft.entityframeworkcore.8.0.11.nupkg",
-        "sha512": "cf5d52c7f5d689cace47117d72ff5fef566fd8390006af8001df649bee0a3196ec381b00880db9b83926c5b8a559f7fd397dcb5db15c19e37b7a11bd04b91cd9",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.abstractions/8.0.11/microsoft.entityframeworkcore.abstractions.8.0.11.nupkg",
-        "sha512": "64080c34faacc6cd5831101c8b2245a58c3403ac0b1b5f6b4319ef3f5213673c606cedf541230c599714c49d19e88aba36bdbd4f6281e4db84d4f2c532d6afb7",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.abstractions.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.analyzers/8.0.11/microsoft.entityframeworkcore.analyzers.8.0.11.nupkg",
-        "sha512": "dfb27bfc753587d6f7c6c518bfc3743ed2ee1e35c048a9e0d2512b916f7f3ccc616248760bc780d7217097e3ee076048c24bb2e488b7722576438adff776a83f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.analyzers.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.design/8.0.11/microsoft.entityframeworkcore.design.8.0.11.nupkg",
-        "sha512": "2599c8a3081e8936ebdcea6f090c3611deadbbac48da95f84d922a9fd329d5399337752b2a1381240339f1656e43c4032619b70866dc58a2fbf835c2c2e9e255",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.design.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.relational/8.0.11/microsoft.entityframeworkcore.relational.8.0.11.nupkg",
-        "sha512": "6bf9071342ba151e8da4a28e9cbca2f4a15391c6d4d8e35e281224dfa7baa5b31bb5af34099d37ed3de92dec2aa98b8c80226b852a0fc794bc482ce106c70b1c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.relational.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite/8.0.11/microsoft.entityframeworkcore.sqlite.8.0.11.nupkg",
-        "sha512": "bd6cf8b7574693c262f9fa2c7cfdd59e4cf30999fb5bf6477151934a19dbfb21f94ecb8c9f1b1b9d1a3d3f6e70b541855d37f8c277ff30357edeedaef2dbfb18",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.sqlite.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite.core/8.0.11/microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg",
-        "sha512": "798a06456c660e67bc1e3a2c1049249fe2ce70d3317615ca353562220f7e7e8bff0db2e36b0f392e1e931765084dcd9229c6954c053a04f6b87ae9f2d1f88c75",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.tools/8.0.11/microsoft.entityframeworkcore.tools.8.0.11.nupkg",
-        "sha512": "1ad3b75bed1d444b631b344c9f0bc186d14863ecf8988233e52b53cc7e825e58fd61d5d6e38b2a623b3ee7a307d6f2900fec902a1c6aad0669ba3ea3391d0561",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.entityframeworkcore.tools.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.apidescription.server/3.0.0/microsoft.extensions.apidescription.server.3.0.0.nupkg",
-        "sha512": "0935055d9b547f1feb24c9777a9d44dca03bb2218311d9b541103c724adb7a5b447ebf87b390dbcadb9380f05ffcacacb2fd3ad738f285cb25f70dcb24c6ab9b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.apidescription.server.3.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/2.0.0/microsoft.extensions.caching.abstractions.2.0.0.nupkg",
-        "sha512": "fc1f7d3f267d86ce18ba04aeebce36b4047f5a7c3cb2342a4209d3c0f1b0fa2f07ce70ea82a85442e9c9a54ec3102d63e5b88098a3f7c08468a835fb51fb423e",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.abstractions.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/8.0.0/microsoft.extensions.caching.abstractions.8.0.0.nupkg",
-        "sha512": "1fdc30912cc1ead9362f70853de219a9dc7070bc28f621e387185670e605746ee2f13b0df9db03d0b1f8919d4bdaad40ebe9f8203e3a0cbb61145aa8848be136",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/2.0.0/microsoft.extensions.caching.memory.2.0.0.nupkg",
-        "sha512": "2b46b6dca1b37f2b45c4001f7c52c5195fe2d488f32e2658bf025a1772c875a04555e84991385bf50d51536f6c2d53e16c8e23253da07a52f95d23e15f1a6bd3",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.memory.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/8.0.1/microsoft.extensions.caching.memory.8.0.1.nupkg",
-        "sha512": "39d053a5a92f413d012f910df6716cdac2f1cacfd234531b956dfcd10f1a83ea8cb84d017d4c72e011f87c53db27e33e9dc7c86f842eacdb1907cb895b448817",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.caching.memory.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/3.1.0/microsoft.extensions.configuration.3.1.0.nupkg",
-        "sha512": "314056d5e02a6d57b1f2ad1b9c2c59d27a7326d88a08c5b938758a08162d49c9b227e89354ff4fbfa47d2679c5d1463e3eca489033cd5eaa38a71422fc757ecb",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/8.0.0/microsoft.extensions.configuration.8.0.0.nupkg",
-        "sha512": "da48a8ef3b4cd2a6beb78008382d9fccdcdd42ff3a71d9efc5ac69d4020421294ac95b07cf11520341a69ee241925cd040d49a382df243e2fa194f6896ef9734",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/3.1.0/microsoft.extensions.configuration.abstractions.3.1.0.nupkg",
-        "sha512": "13ebe935f71a5447ecf5729d177816dbc00b052ed8908c7371f62aef3510614031f6279e694d6ea3baed141c91645568c98290e9445d6278db2455e28136d1d6",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/8.0.0/microsoft.extensions.configuration.abstractions.8.0.0.nupkg",
-        "sha512": "3316170910a94290c8df4fed26fa884a47dd9bf974eb7ad22368d5a63308660a01d2dab4a44662061dacaeccf4ba09cdabfccd4636f76ab3178becec5ad31a2f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/3.1.0/microsoft.extensions.configuration.binder.3.1.0.nupkg",
-        "sha512": "965cc4ee738f92c9059492de62cb6984db69d420d825ffb13bf03793df481aea198a6f343d922807659f5ab07c4e9440ad079dbd78f5898cec25a59a90245a0c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.binder.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.0/microsoft.extensions.configuration.binder.8.0.0.nupkg",
-        "sha512": "9a5931e9d417b8cd4903fe8b94aa8ec07a1f0d43386717be38171a5eb432b1765d7da95e7f092e6997eccf3f4828d5716317a68fcc8fed32f0ad4f1f82bb7223",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.binder.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.2/microsoft.extensions.configuration.binder.8.0.2.nupkg",
-        "sha512": "63f5d5d0f5df1c7f90a138c75e14d81f3598af78c2c736a7aef5035ffcf9d40ac5a133571935a08290ceb92db72357c8203261165f8f7f057c450b2c611f6c2a",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.binder.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.environmentvariables/8.0.0/microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg",
-        "sha512": "e7e284b1af1362db2ae4ee6df9fff7b4766df63861837fed0019a43388f688158b328b45dc9188ec966bca8e0f1efae0eca9be739b41de24702001942e103db8",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.fileextensions/8.0.1/microsoft.extensions.configuration.fileextensions.8.0.1.nupkg",
-        "sha512": "a9727a08418460a2c66da8ed447cd9ca199157e43e22b84fb0d642cfc4b7b74cb577c3bbd7217b6abc3742fcba7b8e35f873a1a289ee4315c09ce5f1b94ee9a6",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.fileextensions.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.json/8.0.1/microsoft.extensions.configuration.json.8.0.1.nupkg",
-        "sha512": "b61e38d1accfadeae40c670f9414eb360987db39024d0619986733334a63a88aed9727ed8fbccd2fb906f1e37f3b3df8baf01c1cb819b72f452c559f02cab37c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.configuration.json.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/3.1.0/microsoft.extensions.dependencyinjection.3.1.0.nupkg",
-        "sha512": "d1f4b1f75870cba2faf333c7a7e8d3bedbce69424b06840957f3be2e95c13ff43e9bde14d48efb982656f31208997eacae9cb1ba2d54b3ad6d49264bad727cae",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.0/microsoft.extensions.dependencyinjection.8.0.0.nupkg",
-        "sha512": "96391af4ae0542f4ae96c8009c9ffbf304acadf476cda262a8ea73e33b172529541044186c59d656377bb2de42c9f5925e0632a81f6e7516f2a646e8916f16ec",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.1/microsoft.extensions.dependencyinjection.8.0.1.nupkg",
-        "sha512": "b6d2c496ce68bf91ac7499eb2a8aae34347e648b9be853e535a36044afcf8173561650aba33068346f458062f29c8e0c1f5859f73800d512ec0f464dd467d00f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/2.0.0/microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg",
-        "sha512": "54deb3578c6430a23120fe3c910cd789e64f59751e18bdccd6742f8170a6e38100be2d9e0b48188ff95dadf3dd7b8245dd33b2a4010d66fb895f5aa44c50207b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/3.1.0/microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg",
-        "sha512": "e184edffadaca3c7782695c8d291ebdabb42bd1b67a0764355c6ce9a186f8d186de36924288eab3978d07318f3aeb6f14e1a883d6f69f8e69a1948486a3ae577",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.0/microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg",
-        "sha512": "94bc05ed29755109565d9cdfc901087ee1fa08302dda393106bc9a0bd7384f0dc2b6c2f123c1bd53fce06babdbfa845dc6d22a163c4b0646c5251dcc5aeac282",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.2/microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg",
-        "sha512": "ba1960ef110ac7387a2a06eefc02c59ce57b0fe58b3e0cccb79b1c8f2150105c5d1f4b65e0ed95ff50d70f28142917c6a735b83f4e5406bb1d8f9dd1f9635d7d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/8.0.2/microsoft.extensions.dependencymodel.8.0.2.nupkg",
-        "sha512": "42a9e54c51b5f99a1d26ae79ce21accb5218a600b2534632aa2c2a4cdcac5d2942d2976f2c915fe8523ec5e390043607ac6b0a530de9e7cbbad9e1841ecea37e",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.dependencymodel.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics/8.0.1/microsoft.extensions.diagnostics.8.0.1.nupkg",
-        "sha512": "a668c7de32c39384a0dcf85abb12560b2e286441ae269b39efea7149bb2e4a90a8949d6f941b9e24b8b3642f15f86b8a968f36183d97695019bd23f0ea7be237",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.0/microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg",
-        "sha512": "a75dd040e3e03e90c8baa006bd569db9fd09983cf9c27bfcb246d96a73e2595cea7aee6116438989f8df31b56bc7fe6adaa7a7fcb6ab95ec5b1d64d0b17ff617",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.1/microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg",
-        "sha512": "267c18ce804b572b17d9256b41c544428c5586c144a6815f864408f08ada786ec8ec239bb7a89d985571ad3e962fdc4a059511439db4936c0bdbd660bf002f46",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/8.0.11/microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg",
-        "sha512": "b93febd5e681c26766d890feb34d1062ce66d44b84d1103f8c1d4a80ed0964ded8ef2551fd6bcfeab1d95fd8c5922733448954bece46d96c781b9ae984a08ef5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.abstractions/8.0.11/microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg",
-        "sha512": "0499640470c8390fee1a1fbc7a34efd4ef65f3ac93fe871420b6c844805e7711e6c98a9f3b1e9f1d8f598a247ef6d14e9dcdf3b442f31a65fd64a93ef3f64680",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore/8.0.11/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg",
-        "sha512": "962e83a815dd873648d722b9aa791298a6a6f1e82c11787f369babaa59fe45eef088f9556ec1e99a8ad9a18078339de3892dafbce4ed444d9e7a4d4e85135a7c",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.abstractions/8.0.0/microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg",
-        "sha512": "fe9aa18f2e819694f20e322c93e075e27bee2d57ddd5380624fc48a95669c526c270ab5c74f58c6a4721d18ecdb5b2febf0315f8794585ae65617831459e2a0b",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.physical/8.0.0/microsoft.extensions.fileproviders.physical.8.0.0.nupkg",
-        "sha512": "7612261a35b76d0b3a337ab262de57c3b605e8a1e55bf4d47f15e374e5577ab2ce4ae370980ef2c1335c4e323e6adcfe3718eee86570ac6e4ff5cb100450331f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.fileproviders.physical.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.filesystemglobbing/8.0.0/microsoft.extensions.filesystemglobbing.8.0.0.nupkg",
-        "sha512": "23a5e50cf695ba18c7a77f7c050e40d6fb065957480db17f5e75e5cf269c8f50763c996c28d0dcfca09e2c1248540898ab53c474cadc705548f5fe491dd263fd",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.filesystemglobbing.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.0/microsoft.extensions.hosting.abstractions.8.0.0.nupkg",
-        "sha512": "6788c16c139ba241cf2c65e4ded10b8ad8b38602b4490a5ff27dd52b02c90083b7cd40c7b4fac48aed94742f6545da959870b5d889b41078b22708acd761da66",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.1/microsoft.extensions.hosting.abstractions.8.0.1.nupkg",
-        "sha512": "4c7ef392ffc0c10a17b3bbc1232954fac16ed7e7e51aaaefd1e68f63eb19ca0b409f991bb72b4a1f9e7ecd241f196e579a2a740017cfe08b64c75062d60508e9",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/3.1.0/microsoft.extensions.http.3.1.0.nupkg",
-        "sha512": "7692b3ada00fff278826bede064e734889b0af77cc4a8f2865d40d2e7b437319b5f418abb1383717cc69aba94ea0c65de0c2683d52e3a10b788675e63bb72d21",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.http.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/8.0.1/microsoft.extensions.http.8.0.1.nupkg",
-        "sha512": "296bd0a65e3591df63d64e987c781c32fa677a08c84fe2911e6288eae94b1c77dd2a134692b5bfdcac93a4992fa14b69bbb81cfe3a1e7ff2e90d5babe917ec71",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.http.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/3.1.0/microsoft.extensions.logging.3.1.0.nupkg",
-        "sha512": "fd20e13f2908b212746f0b87df684bb3ca3599f40ceb72b7813be343b7dbef4d6865dd83c370d9ff719f88366f4998cefa481222e926db27dacc2493b610d415",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.8.0.0.nupkg",
-        "sha512": "aa30576c428dff69bac5f5d71721af6c4ef583bc524edbd0a94b49cbd80f698905021260e1a432c32e6d48ce5a30f6822c209f11dcf7c819aba1fa8347925b06",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.1/microsoft.extensions.logging.8.0.1.nupkg",
-        "sha512": "ab3363c4e103963ee5013ada55fddcd771961e48e5124f41e70589e589dacf27d20cff7e04bfc214db79fd937cbad80e99cef565f72e0cc10b84d9b3ac0619fd",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/3.1.0/microsoft.extensions.logging.abstractions.3.1.0.nupkg",
-        "sha512": "303b2749a54bbe683506e8981c39e3c3a9f76a08bc6eb9bd7ca7204079c6a88c68191a5247656e8c9138633be1a7758205b3bab92fca4a1e3a774b96315e6a63",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.0/microsoft.extensions.logging.abstractions.8.0.0.nupkg",
-        "sha512": "50a0add96d30d90580fb8e02a25cea0aa15f4d22744279b5acfe18cc8568b74402aa062d5db13cc5887a08bfd24e07cbc88b2fc10ee8eec2c37edf3bcda7f8a7",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.2/microsoft.extensions.logging.abstractions.8.0.2.nupkg",
-        "sha512": "f8b9df3fa7b837cb5f2fa53a86bfd47279f81bc332db55b8bb7ea14f55dfe2158f351d35199c0cc0e01c735f394ded2a3a8f1c85c3ff6ea1c3ab785bfbf362fd",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.objectpool/7.0.0/microsoft.extensions.objectpool.7.0.0.nupkg",
-        "sha512": "ee96a7f7ddda2557def993082c7d7429c25135b37b80df916f0427ee1349778722f10bd284810482662dee5c2f011fdb00e188626e7cde5c10c4b8718fef6639",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.objectpool.7.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/2.0.0/microsoft.extensions.options.2.0.0.nupkg",
-        "sha512": "afc8ef803afe1d832eb86f023bbbd5dc14b76583ce191338dfb2f7ff030adcec71d35aac194d4efcf0d08e5af572e2205e848fc137f8812f8ca85bde72e11e33",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/3.1.0/microsoft.extensions.options.3.1.0.nupkg",
-        "sha512": "643aac9c2d8d0aba135f9259d56d89a5d6b760723c694fd10a2ad3c8da291f535f27e94a733fbd7f80f208b1fd98ac6b5980c6546a3a1093eab40d7bfd617a9f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.0/microsoft.extensions.options.8.0.0.nupkg",
-        "sha512": "1c004082a132e7b75a0c95acef3578a4d5db42c55e0996e40b95b663e9a83c5a20ed481a85db7567fff7e3de3dbba6a7d4fe5c825dc7ce95de956689afa16c5a",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.2/microsoft.extensions.options.8.0.2.nupkg",
-        "sha512": "cc0c10336580c9519740a042b1e42d391bcb32b63732163ae1161e1c5b55a4cd4a736e1902eb2a4dbb89d784b0acf584b5042b4f3481a61dd30a4e229fb523c5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.8.0.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/8.0.0/microsoft.extensions.options.configurationextensions.8.0.0.nupkg",
-        "sha512": "5c32ae67ae4e873216bbbec15554778e0acbebc283862a2debcb11a995c42a5fd75f9436c8da421aa51bc5c12db4e6c4e82f12da1ff942bc5a6e1a8cf3c77a7d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.options.configurationextensions.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/2.0.0/microsoft.extensions.primitives.2.0.0.nupkg",
-        "sha512": "47284b149a0cb337dbbb5af3fe0ce8aaf3ab760b275f193407f3387ca8ec25d6fafc8dedd8c755ab8b35756b3c84e5ca8dcab6ea8bec2cbd543cba304ec69371",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.primitives.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/3.1.0/microsoft.extensions.primitives.3.1.0.nupkg",
-        "sha512": "abd8306bc481c1aa6ac016576e2be6be4332037af80dae407896727684e799d5147af2fff39a05f5be3e864391d5753897b7f35d8c57fc7221f5c4783e002ce5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.primitives.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/8.0.0/microsoft.extensions.primitives.8.0.0.nupkg",
-        "sha512": "1f5475ca3d3ce18463456dd135afac502d6f82fea6e4e4814a61f86616c348decf28b73d15c2bb276d1a3c039ea6064f75e1329f6f3a64caa3520d70ab92c32d",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.primitives.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.11/microsoft.netcore.app.runtime.linux-x64.8.0.11.nupkg",
-        "sha512": "810ca3d4ab581a01495939f8b533356c7e31bd3c95ca4e692c26191e591899f5f0a35a0356f2eb5e2382deb29d1f103e73cb5178f26c3432102880252659a002",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
-        "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.1/microsoft.netcore.platforms.1.1.1.nupkg",
-        "sha512": "9835090f578b5c8ce6527582cd69663506460e9fdc5464fc2b287331c24d9369e57dd1543a865a8bd89d4fcfc569c26bf0dbfcce102675fdfd1479b9a9652819",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.1.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
-        "sha512": "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
-        "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.openapi/1.2.3/microsoft.openapi.1.2.3.nupkg",
-        "sha512": "9d8710a99c1a976014c0a4a837d021fa58fd13d5c1d573861e357c43ab1b4ea73ea85cf72afab0a3dfa5738908ade7ef6904e2d280ffff2ad9cfc8868c228461",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.openapi.1.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
-        "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.registry.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/8.0.0/microsoft.win32.systemevents.8.0.0.nupkg",
-        "sha512": "25016c508653fbf463c52d8fc3d2773b7c211c2402c4ea7b4aa987fb29c851d3f80c5e7abbcace2d4d5e061ae290524e8029afbc49a37d7e5186fe06aa4609b2",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.systemevents.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mimetypes/2.4.0/mimetypes.2.4.0.nupkg",
-        "sha512": "3d25e35d5e893dff932db404e2d9151be7da8e1cffe213d7689199dc81b337472e24fb6517db5fbb481f05676abd0b367f2e8ddc8b6a97af4dd6a273531e514e",
-        "dest": "nuget-sources",
-        "dest-filename": "mimetypes.2.4.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mono.nat/3.0.4/mono.nat.3.0.4.nupkg",
-        "sha512": "b2909720dc40cd459741e4ad9af16cf8289dd43f5fe1f90a28f26937da8d8ec4621d3b296019a94bfe5c871ef12b41f49dc85c415e656d5376a3b1fa48d63973",
-        "dest": "nuget-sources",
-        "dest-filename": "mono.nat.3.0.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/mono.texttemplating/2.2.1/mono.texttemplating.2.2.1.nupkg",
-        "sha512": "22627ee103feee11c04c4eefb33b3ff874cd5553c71a4287266465b3bedf9803d27bb998ce736c9b977f79b436a168823a9d33637183ce466470c098187acb6f",
-        "dest": "nuget-sources",
-        "dest-filename": "mono.texttemplating.2.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nebml/0.11.0/nebml.0.11.0.nupkg",
-        "sha512": "07dc3630b81d5e4a29be8df8178d6fba6f7bf20396bb5217af2941b741d88764e0a91e8d524249a9a94dbe8dfd5f128e4d8556e71404d63b521a493a8ccd9965",
-        "dest": "nuget-sources",
-        "dest-filename": "nebml.0.11.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
-        "sha512": "99b252bc77d1c5f5f7b51fd4ea7d5653e9961d7b3061cf9207f8643a9c7cc9965eebc84d6467f2989bb4723b1a244915cc232a78f894e8b748ca882a7c89fb92",
-        "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.13.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/playlistsnet/1.4.1/playlistsnet.1.4.1.nupkg",
-        "sha512": "903c52d34062831b99a6d632f175e22e9afb247ae3618bfce8018b0595784264f0dbb0b63bf139d65dc8e34efdf15bce9e7608af1a8dee87765523193f85a850",
-        "dest": "nuget-sources",
-        "dest-filename": "playlistsnet.1.4.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/3.1.2/prometheus-net.3.1.2.nupkg",
-        "sha512": "140f9817fc9da297eeea6b7b6d03303d53364268bbda89cf76f56b37692c94c6fa160c2d0d475fc1d07857a64f21b0c7202178a5aaa0e64048254b6a0a439ad9",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.3.1.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/8.2.1/prometheus-net.8.2.1.nupkg",
-        "sha512": "f7094a591be84d1b8171081cc0c30e8ee4d2adb9118eb52fb53830f789de29960e86e17278dd44da439b5e463151fd7602dbf5bdab838c2b4626812b3d2a4ccc",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.8.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.aspnetcore/8.2.1/prometheus-net.aspnetcore.8.2.1.nupkg",
-        "sha512": "3ab7a9556aabfb429f87478b6e7e4eaed4445832189c670a245e8c77349946c6c2b278f30e6bfaa9ee9a5412789b300a70d96d5cf5d5f1b42b996f70e9660ffc",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.aspnetcore.8.2.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.dotnetruntime/4.4.1/prometheus-net.dotnetruntime.4.4.1.nupkg",
-        "sha512": "62712e2d734722927f6ee382dc4341efd0267549197dafa300e57692d40b46e7640d12c14452c0a9d298bc497b2831354fa531403ef64a0c8a187f1f98d951c5",
-        "dest": "nuget-sources",
-        "dest-filename": "prometheus-net.dotnetruntime.4.4.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
-        "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
-        "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
-        "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
-        "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
-        "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
-        "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.0/runtime.any.system.runtime.4.3.0.nupkg",
-        "sha512": "bfee3c68312296860e5459af5e770c2e9fcd4ac134361fd569a9ce1e6574b9ae3978aad403f89639a4b5bac8ee5bb0ee1b8edb819e9a60f13ca5bd1812889bbd",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.runtime.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
-        "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
-        "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
-        "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
-        "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "8f071552ee042f0cba39b1ba0a1205cf73de447d662995bae68f857a5946f7d154c029a79e37469081675687873c8bf2b9efe57f5cbd660c366b1ca51823f7f2",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "a135ca0f4f5a49319b5a52b7f4338f8a5fc4387edf26f29e6cbf63a3c3a37b2b5c51c9caf562ec41e470fba281060362465bc56915be782d6c75778aa6195e46",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "2f24e2cba88a96bb23848e1404878e4478a65642387b7b76aa4007587fe7c4d8208cbde53d3ed65f8d0d71cd688bfc16be66dc5f7bcf84c7b2ccf1b3c505b0b4",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
-        "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
-        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.2/runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "a34ad2dbe67efcae97fcbea57af386b30660a98ab8229a56c0dca241316e673cf7a26e19c6efb6b7117cc271fdf208741ba6f8447ae254c91acba3ddb7d2923a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "ce0873e07000df98e640bd265e969d4a9236535cee2699c5363f3ab297557b0d756260557995f2ee163cff05fc2ba922d66ba0e4cb28521f841e7d546ab3b63e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "bf754c1a66cd70dc1bd38d54fe675e9dd470417ebba62e2f79e278be8f06cc3496ff58ed90d30b5dd4d3efea9accbd09eb17cd87be882951c0fdfb833c371f70",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "cd4b7ba744de80086521ab67cad2db3085d488388d3d9cb83d9946389f0f4c784539bf3a4ffb8d4f3347c5c7813aadef95b355fd2563e30c948a883c27b95287",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "d7fc28a9f600e471edce0989c01c485d4e2a7e99551f531413afa75039a4004d4e2c27e88976d65432635a321d86316a3c6cdaebc7b2fefa42141b64f4f10d66",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
-        "sha512": "5fe0e6a878eff59cfe24a8d57af51140576d8e0fec4988e4892c233c47b3a3eed27dec072a6c0d55dd615777cd9ce3fe545c5353b4a95289376ad0b9408ed4be",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
-        "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
-        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
-        "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.0/runtime.unix.system.private.uri.4.3.0.nupkg",
-        "sha512": "203ebe272791d79ab0c40afe9d0543852ee91b9fb4ae5bc15524d97728bc8bc9d7e0cbcf65d1fab8cfb0aa7a4ae37e7938933eef127aa5ea46f60e57b6ad2d91",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.private.uri.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.0/runtime.unix.system.runtime.extensions.4.3.0.nupkg",
-        "sha512": "54b81784c08e934389c59e6e155af6b1855e4bbc41678b01a702c94e6daba87c6ddfd16fe9e2cb61f3097bfa4950dbc37781454d027ce5ba6c50a393cc91b888",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.runtime.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/3.1.1/serilog.3.1.1.nupkg",
-        "sha512": "02985d43db0efd5e56b086e0a29af986de381a163a8633ab81a88b6620a3df380afc4506366beba0f214ac8ec37c8d435bdf130285dcde331b14733e62fab8c7",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.3.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.0.0/serilog.4.0.0.nupkg",
-        "sha512": "1f6279bcfa93ca9c13180dd7c7e5944d5351358b9cd3a360cbbf12f2dda508700cb9ffadeffd4dfe772a6ddb2c029e2c3473e655a3b660a644de51d67133268c",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.1.0/serilog.4.1.0.nupkg",
-        "sha512": "4b0bcbc6ef35b4d1914dc870f3ecafc4a7e320b66842f8fce03d733874fd4d171885343c91e43dd1d5e49f55c50f948cf6c681c64819a8632187309ff82be15a",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.aspnetcore/8.0.3/serilog.aspnetcore.8.0.3.nupkg",
-        "sha512": "d46d53d19ea7c1c00eab3064fc995ca7d455df983355490d4053a5bb6e51164f74e007d4cdf1ed20de7c85b19bb65507f61645f2c3472cc386fe244230bd5f4a",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.aspnetcore.8.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.enrichers.thread/4.0.0/serilog.enrichers.thread.4.0.0.nupkg",
-        "sha512": "d776603c04a031634dfeb64203e3ed4204eb96d503ac8183d5ba231259c55cd4411359116164271e38ddb949a9c4604f4946021c52c34044cda85797e6b4a7c2",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.enrichers.thread.4.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.hosting/8.0.0/serilog.extensions.hosting.8.0.0.nupkg",
-        "sha512": "580cd1e3c1099bb8774504409e59cca246dc1e5754cc6a0e2085ca03c4ecaf66088e284d854c235578db3d0a449a854015454b686c0bbb1c299ac9c052e14a6d",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.extensions.hosting.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.logging/8.0.0/serilog.extensions.logging.8.0.0.nupkg",
-        "sha512": "cbe725d5313d4cbfe551ba20b6686ea02c17a6572b79170d312b3e31e3763b544276de387bfadd98bf623d602aabd5c6fcd131a2a29dbf7204c649a86d1cd8f1",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.extensions.logging.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.formatting.compact/2.0.0/serilog.formatting.compact.2.0.0.nupkg",
-        "sha512": "a4a87b075d4dea0f3d481669206a6488890e5f4e5615be587b9d4c74ff0b8bea260fa19e85610ef24ce2ce7af49cd561f4e2212769559352aac9325a234462ee",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.formatting.compact.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.settings.configuration/8.0.4/serilog.settings.configuration.8.0.4.nupkg",
-        "sha512": "04f71c87368908aa672326229cb5286cc14565124f539b2d19e4524a50bacbac9b4686c0cad52c8f0324e288f13620e0154a7b64d5abbd176a100b33ca32cc73",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.settings.configuration.8.0.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.async/2.1.0/serilog.sinks.async.2.1.0.nupkg",
-        "sha512": "04c6181f987cf459d96ffafca2a7cb7d5bef0f5b079277deb5ac009d238929ff8b075b2e73504330505462d76652ce106966dd3a0407c8799bfe5d0bec7f0fdd",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.async.2.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/6.0.0/serilog.sinks.console.6.0.0.nupkg",
-        "sha512": "49c6a20f42a9b46d8cccd76d287e92210aeb967d8f8daf93be82561fa050d91f927d0bb5ea81a147caa899b9abf47b616e5d74a8cfcffeadc1545da0b73a979c",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.console.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.debug/2.0.0/serilog.sinks.debug.2.0.0.nupkg",
-        "sha512": "fbddb39441be29aee4077c487e321ab0c3a167adc74f698115a5412d989e4d33c2a8d1cd9fcb96b312c567cb293d23f8431c936d9647691e019600a405c5cc6d",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.debug.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/6.0.0/serilog.sinks.file.6.0.0.nupkg",
-        "sha512": "90daa5403374597318b8973f4a7725dd14d44425a75793c82baa4143aeb3b4aeb8423636edd2b3b82a9df367d4e42339e73baaf62d42c87e7d4a958fa4394609",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.file.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.graylog/3.1.1/serilog.sinks.graylog.3.1.1.nupkg",
-        "sha512": "4509679ad467ca5c96344e08ed507684acce267d31865c3057bf1eed88fa2b66f9fd85d142669dc2fbc891ed82a04fc45d82aeb65d0ff2f4a4903fde37926470",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.graylog.3.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/seriloganalyzer/0.15.0/seriloganalyzer.0.15.0.nupkg",
-        "sha512": "c0ddb69f4e0ae258ceb8ce7ee6923b6aa6f815246a347684832fb7c08f9af696435a11986b73b2f9325138bd3da0932681127e166102f6a6b92943bd0c0e3e06",
-        "dest": "nuget-sources",
-        "dest-filename": "seriloganalyzer.0.15.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/2.0.0.1/shimskiasharp.2.0.0.1.nupkg",
-        "sha512": "babb41bfc0354dea0b52cc70ea9e9510204e33b0a8f544ceffacfaa919bc7ba26a24493ee70fb5a30758320380e4d88163a7daee0f663602db0365956eb7c0d1",
-        "dest": "nuget-sources",
-        "dest-filename": "shimskiasharp.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.9/skiasharp.2.88.9.nupkg",
-        "sha512": "3a2ffa5e05f45cdb80e6735ee947e91e08ff145fc50c7882e75d44b6ae0c2cd733420d15b6a4274a186b3a79d463a1273e27ff7fd79a51d0937251ebb6ef761d",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.9/skiasharp.harfbuzz.2.88.9.nupkg",
-        "sha512": "7ebc75df46b3d2bfb110324dc0613fb1395667219ce42c757fb98f0ff60b755fc69fe6bb94613a2be854e8feecdebe671ea46cd9e8a0df2e90ff7d461ab123cf",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.harfbuzz.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.9/skiasharp.nativeassets.linux.2.88.9.nupkg",
-        "sha512": "5c6a3e93a18e70e6adcd548bd2f76fa311114346ce4d812e520f250d33342d5ad8d05ea285433bd15cb19bbc48d9bbf2ef7d1f1725dd71705accefaba3f46892",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.9/skiasharp.nativeassets.macos.2.88.9.nupkg",
-        "sha512": "74cfb865746f2911935290bfb92469b331e50415d5abeda87598ebdb4049c52af84a5daeda41ebcb0bbaec6a7debb42d83cdc6c9f61cea55d43c720a78c3ebce",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.9/skiasharp.nativeassets.win32.2.88.9.nupkg",
-        "sha512": "d18bd8194041c7ffb79302d4f1be584e8c024e88b12cb4669a738cae551da3d3e3924087bb0aa42d34a9003cfb35037d73637894e67d02223d100a1b4215eeec",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.9.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/smartanalyzers.multithreadinganalyzer/1.1.31/smartanalyzers.multithreadinganalyzer.1.1.31.nupkg",
-        "sha512": "0e703633c4e989fd218620ec76a21bbbd9dce34f313ea1dda8d698be11ffaf08d959b8e2d9c964aa661e7dff3611003504c757ce8cc956d8626fa2ab21c482fb",
-        "dest": "nuget-sources",
-        "dest-filename": "smartanalyzers.multithreadinganalyzer.1.1.31.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.bundle_e_sqlite3/2.1.6/sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg",
-        "sha512": "69169044def48e943aac624d83be72ae09b046b7f4bac1efcd2aebbe02fa9847ad8bc5303b05834b39880c05e33ce64a51a34f5887a13bbc35761d72ce086baf",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.core/2.1.6/sqlitepclraw.core.2.1.6.nupkg",
-        "sha512": "16bc39cd5325dea37e1564fc328a35966d6d820878290d945dc57496b716d4935b534285989af32fa7bd25ef9a8ac795b63e6a19044d3f84a104d643319473be",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.core.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.lib.e_sqlite3/2.1.6/sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg",
-        "sha512": "69543fcac6af6520b638ed00c5f8f8dc59747376382c561ca82904780214b3e75cc4293106c4a3f6f671b73d591195800c44afa2d4dc533a8257b00fdf77d663",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.provider.e_sqlite3/2.1.6/sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg",
-        "sha512": "527cec74f2ebeff238b3bb1f898637576659537aa6f2c5a4384b1c1b094cb772bfe86f05c13a1020247bd73fed8759c0bf568a1c0059c1d87bbbed2db1018701",
-        "dest": "nuget-sources",
-        "dest-filename": "sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers/1.2.0-beta.556/stylecop.analyzers.1.2.0-beta.556.nupkg",
-        "sha512": "08163f6061ebc26ea9b8069a82e9f575d656a50f1d9299eda874f4107731eb2e02b512f201f1c34c6983d92baecd6ee5e992aa6b61c78ae9490a7fddbdd51882",
-        "dest": "nuget-sources",
-        "dest-filename": "stylecop.analyzers.1.2.0-beta.556.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers.unstable/1.2.0.556/stylecop.analyzers.unstable.1.2.0.556.nupkg",
-        "sha512": "0e9fbae713d2d30690bb331e7308a619894ee26c13798855ec0a2529b32468d67fbcf2bc1f02aa0f3ae7e6851d2b595684ef415245aa8119b9b1b7d58c30916b",
-        "dest": "nuget-sources",
-        "dest-filename": "stylecop.analyzers.unstable.1.2.0.556.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/2.0.0.1/svg.custom.2.0.0.1.nupkg",
-        "sha512": "0ccdaba6b38665c31d2e660a5983a980584a7ebb1a999d91cd3acfa3861f68a428a663f3fdf24093bed52f7628b9d2ea020a1ab6614d846c6c8a2515b90b2312",
-        "dest": "nuget-sources",
-        "dest-filename": "svg.custom.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.model/2.0.0.1/svg.model.2.0.0.1.nupkg",
-        "sha512": "a02226f89e5c5ce81b49a1a38bda8945f070849fcc557fcf3ad2f500430c0e1410ee542681fc8b7a2d560c4bc00a084f58f96f001ded0ad94254d1e2d05fba67",
-        "dest": "nuget-sources",
-        "dest-filename": "svg.model.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/2.0.0.1/svg.skia.2.0.0.1.nupkg",
-        "sha512": "eec0ec97de78aca75af5aa5523df5afefdf7a9cdcea0379669d001a82b4fa3a3882a82614b4ab25c6436a48c9834d3d1e19e669fe32d1396d4c8bb6c712a94ad",
-        "dest": "nuget-sources",
-        "dest-filename": "svg.skia.2.0.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore/6.2.3/swashbuckle.aspnetcore.6.2.3.nupkg",
-        "sha512": "3e491d5f00e2ea8c26170ed72c0ab670beb3d8178baff82a4aa8e97986791f65125c62a73e413d5d6b435ca2205e2bbe92d6e542a504a7ad2cce552eb3548f93",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.redoc/6.5.0/swashbuckle.aspnetcore.redoc.6.5.0.nupkg",
-        "sha512": "0a2d7427dd148741e5761818cf9a920b198fa235304abc00310b56dbb94147734adbadd7c0a3fcfcc32b1443609b248842e8611849c0a3f56419a4b3007f1488",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.redoc.6.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swagger/6.2.3/swashbuckle.aspnetcore.swagger.6.2.3.nupkg",
-        "sha512": "c12fd032b76e9cbc4697b3bae1f123807410e3d5a8eaf3558a1840880f8bd30fa5dc4b316e86575310eb6eec1924467e0c9c02631afb10e20ec9eead6da3f439",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.swagger.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggergen/6.2.3/swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg",
-        "sha512": "777f7ac29a52dd45bdcbc4a2f426e12f5f8918b9d7e018b4cb8c8f26cb2f40bec77378c9cff23a951170559a9ef4b24a25ab2a3a2ddff63a30cec9240e535912",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggerui/6.2.3/swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg",
-        "sha512": "90e6aafa82fbdcacba8b48a2f59bcb6418a5ecab7e7d659b44ce8d8bc5a3aa97ee168e85a971e8d4cc5d78e3e1f9e2a5cd0e9e4da09cd8d32f898eca4f74b397",
-        "dest": "nuget-sources",
-        "dest-filename": "swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
-        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
-        "dest": "nuget-sources",
-        "dest-filename": "system.buffers.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.codedom/4.4.0/system.codedom.4.4.0.nupkg",
-        "sha512": "13f96f49f3053ed35f94081d33a02e3d4f096d976a752a06a54eba1bb4ab76e0aa76b1723df95aaaa57880dd9dd21ac2069bbdd876a8aa950fe5dfa0f48b5cc7",
-        "dest": "nuget-sources",
-        "dest-filename": "system.codedom.4.4.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
-        "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
-        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/6.0.0/system.collections.immutable.6.0.0.nupkg",
-        "sha512": "f8036412e384c5c5af6d28f4eab2543207d2ebbb16c47b70f6c471bc5aa4b9f44404c47d776d295191f20a89caa898abd73a2304dcaf77979174ced2d9160169",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.immutable.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition/6.0.0/system.composition.6.0.0.nupkg",
-        "sha512": "48618297e7fcf02b05bce032bcde1882be780e0e6d156b8312855f2a2d080ff590fd7bcc7a296ebddec9d82f654d9286e42b424ce07b112a449be2bfb29bcb8c",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.attributedmodel/6.0.0/system.composition.attributedmodel.6.0.0.nupkg",
-        "sha512": "a53c30b3cfeb4fc67741e85305707b324481a6ac394fb1af71acda01309c090557424a4352135effe0dc37c2953634441994328d89c22532d8fdf8eb7f717405",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.attributedmodel.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.convention/6.0.0/system.composition.convention.6.0.0.nupkg",
-        "sha512": "f4dd753fa196325d1a5e9a06874e88d9651f812f48b013608efe322e079ba194bdf4587603bcd71a86e33f53103c48b1dc8f1776842d5dfb4afbd7e8b4e9dd02",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.convention.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.hosting/6.0.0/system.composition.hosting.6.0.0.nupkg",
-        "sha512": "5a5a331c91f12b6cb63c5dfbea1095980a0a0bfa5d9e336c7316245706f6bedafd76a0b6880ca2c79415f31840c231730285b9bcc3b9474659a28ac9fdabd03b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.hosting.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.runtime/6.0.0/system.composition.runtime.6.0.0.nupkg",
-        "sha512": "ccf6d0fa4a8bb6a170121281728e965df4d346a69c55e0ecefab6b8241959876de568462b7d5dbd290aa6e510cbf1973802466e99b59a7e95b92889052acd79f",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.runtime.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.composition.typedparts/6.0.0/system.composition.typedparts.6.0.0.nupkg",
-        "sha512": "8cf43d8d159dc065c04ad9ec09a60ff431a2fe5fb3d4821c04a02a11687ede9bbc900d82f6d4d6f5d298895c664afbe0e6982b63a20059c5884bdb8c265793b7",
-        "dest": "nuget-sources",
-        "dest-filename": "system.composition.typedparts.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
-        "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
-        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/8.0.0/system.diagnostics.diagnosticsource.8.0.0.nupkg",
-        "sha512": "86e32c62e9773dba192a63bff0e2ffcd57826ed1123c9261fa8c9229f9d1dc26962b3740fb025f6ad5c139162575a6c493b213a9ef3fc1747d15ca0edd0c5878",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.diagnosticsource.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/8.0.8/system.drawing.common.8.0.8.nupkg",
-        "sha512": "318e393b68d144d12d3a41de0dbdaba6796c7be03bb70ead38b5ee7f5581fe059ce78fb39cf4d8e45f1c8ecd194a4b38ff20fd034beeb79a56bfd6a8e33eab52",
-        "dest": "nuget-sources",
-        "dest-filename": "system.drawing.common.8.0.8.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
-        "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
-        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
-        "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
-        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
-        "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.3/system.io.pipelines.6.0.3.nupkg",
-        "sha512": "a72246cbe26c5a7ec098f69798063076731529a3b2e555a3d41692ef5496222328d3988cfbd8e23a54e474f5429df3e478537f85e0dbc145d2cf3c263dbe726e",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.pipelines.6.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
-        "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
-        "dest": "nuget-sources",
-        "dest-filename": "system.linq.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.async/6.0.1/system.linq.async.6.0.1.nupkg",
-        "sha512": "792b7b14a6fcc52f88cc0475a2ba8a694399393fa602446fe23fa6d39d782c16f908b4bc3acd58454554932b7a41056d84424b5fd66f0fe6e3c00178eb3d8a1a",
-        "dest": "nuget-sources",
-        "dest-filename": "system.linq.async.6.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
-        "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
-        "dest": "nuget-sources",
-        "dest-filename": "system.memory.4.5.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.4/system.net.http.4.3.4.nupkg",
-        "sha512": "163edeef734d1f0a1ff7b8053d326eabc82fe86f3de72c6466dd780d59d974487882f2a5f16ae4b02c0d8c8a7f25e617ff2bbfab133f88ebfd6a2f99637169ed",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.http.4.3.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
-        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.0/system.private.uri.4.3.0.nupkg",
-        "sha512": "5989a57ef273b689a663e961a0fe09d9b1d88438e5478358efc4b165de3b2674fa9579c301ce12d2d2fa5f33295f2acb42eceea2ebebf70c733da6364ceaf94d",
-        "dest": "nuget-sources",
-        "dest-filename": "system.private.uri.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
-        "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/6.0.1/system.reflection.metadata.6.0.1.nupkg",
-        "sha512": "7ae13917018aee2c9074db134aaa27cad2d71072f7d80bb13dc16b1de16cec62503b064914d12d86326534c9ed29dbbaed5fcdab7f88b620ae1d1c5022b4673b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.metadata.6.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
-        "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
-        "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
-        "dest": "nuget-sources",
-        "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
-        "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.4.0/system.runtime.compilerservices.unsafe.4.4.0.nupkg",
-        "sha512": "d03f39b62f48714c56aa5db5ddde1613e7f62633734731e611a1b7e2a880de10fb1bc3b88b4320afe46eb649f8a66adbad6f80058e2fce910280799dc3ebd38d",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.4.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
-        "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
-        "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg",
-        "sha512": "0a5baf1dd554bf9e01bcb4ce082cb26ee82b783364feb47cba730faeecd70edc528efad0394dcce11f37d7f9507f8608f15629ebaf051906bfd3513e46af0f11",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.handles.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
-        "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
-        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/5.0.0/system.security.accesscontrol.5.0.0.nupkg",
-        "sha512": "ae6b03ad029d3eb6818a6c8bb56cf4904013fa535a67b8e621b783a029dd88aa2e471e002cbc7d720381ad8bc8c6b93111a08f6ce2d271af6d974bf4d02b6c81",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.accesscontrol.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
-        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
-        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
-        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
-        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
-        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
-        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/5.0.0/system.security.principal.windows.5.0.0.nupkg",
-        "sha512": "44a920aaaf22b2172d41319bb57ab2b8e1a4531d5f02192a6f53a81d875125195b60ba0b5a44a45981d137fd7b0f3a65b12959b5fd97afc0578cd84ef27467cd",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.windows.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg",
-        "sha512": "6ff7feec7313a7121f795ec7d376e4b8728c17294219fafdfd4ea078f9df1455b4685f0b3962c3810098e95d68594a8392c0b799d36ec8284cd6fcbd4cfe2c67",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/6.0.0/system.text.encoding.codepages.6.0.0.nupkg",
-        "sha512": "ec873a95ec517de2c5a5364ada30974ddd5e0fafef2ad2517609a1900b5059d35757536fd073805001fa68d5b56a3d4647010a96c9eb233b1d172a3b45fbe4a9",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.codepages.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.8.0.0.nupkg",
-        "sha512": "77dadf6b1a73eeefb50507a6d76f5e3a20e0ae7d3f550c349265ae4e0d55f0ae4f0ef1b41be08dd810798a8e01dbba74e2caac746b5158b8e23d722523d473ed",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.codepages.8.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/8.0.5/system.text.json.8.0.5.nupkg",
-        "sha512": "13589021ae3e81f54c877abf613ce931cc24ca57bf127af1063ccc1eb4dc57a6cc223a61e6452207f5d0dce453b6627430e31e4143c78e71e9b5dd647f680abf",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.json.8.0.5.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg",
-        "sha512": "97a2751bdce69faaf9c54f834a9fd5c60c7a786faa52f420769828dbc9b5804c1f3721ba1ea945ea1d844835d909810f9e782c9a44d0faaecccb230c4cd95a88",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.channels/6.0.0/system.threading.channels.6.0.0.nupkg",
-        "sha512": "32adff895c57ab9ef864cf89660403f041b07841be7c44a0c3c2c8451a1da076a8c1b4dcf1c993b585304ad7549afa408a0f797ad6814d0f14eb748a1fc9ce03",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.channels.6.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg",
-        "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/8.0.1/system.threading.tasks.dataflow.8.0.1.nupkg",
-        "sha512": "24622fd7d5e33cb55309d0dd35616aa3d6e7aa0c66e1e597c0ca6106cb26cc4248349815139c8f00a51e062506f5fa5f6cffeaa6fe8cb030c64b1d6952224ab1",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.dataflow.8.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/taglibsharp/2.3.0/taglibsharp.2.3.0.nupkg",
-        "sha512": "9be37f6431f6ead36babe78dc6527340d7b4b0fe444736aaeae5aef3651191d4e0421d9d671106aea544888695d7841000fb12f8a44aab1b5fe93fb7c90d983f",
-        "dest": "nuget-sources",
-        "dest-filename": "taglibsharp.2.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmdblib/2.2.0/tmdblib.2.2.0.nupkg",
-        "sha512": "ad0cb6ad203d1ce0f0f2f9f96140326abc0fc54e7b79e38846f6d3431e5c0f17bbe689cd52059931f52f258b16a2ce55fb9f7b2c7ca6b800542fcaf257a2774f",
-        "dest": "nuget-sources",
-        "dest-filename": "tmdblib.2.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/ude.netstandard/1.2.0/ude.netstandard.1.2.0.nupkg",
-        "sha512": "29c5e5a43cd2a0a9dc770ac3ec9976c5ef922622d114bb12cfde950f58d45fbd385e013d170df6fa2d45f9c56d29738bb4240b4f1c3a0e3908d9f99ff938c3c0",
-        "dest": "nuget-sources",
-        "dest-filename": "ude.netstandard.1.2.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/utf.unknown/2.5.1/utf.unknown.2.5.1.nupkg",
-        "sha512": "342b4a01af4cfb0a0b77de0afd7c6393fafc124e72b420ff1f7936891aa259e6a55129d46e54eb5d7fce9759a6ab52ebec89045fcffb23148324ebaa7b604629",
-        "dest": "nuget-sources",
-        "dest-filename": "utf.unknown.2.5.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/z440.atl.core/6.8.0/z440.atl.core.6.8.0.nupkg",
-        "sha512": "e52cd9acbe0eba1c72c6d2967a314198421e029ca0271e4872f37044549173d3403f33e2d391350356c96772938d1fa95ba9c914b238b3929d3c9293469c3fd5",
-        "dest": "nuget-sources",
-        "dest-filename": "z440.atl.core.6.8.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/zlib.net-mutliplatform/1.0.8/zlib.net-mutliplatform.1.0.8.nupkg",
-        "sha512": "c329dc559df3eb4b4bf2f832f37442af6d1be625c97a904f25bc4078684e4716d769ee2c1215329e78a299ec0f6c8a90d6ed1e3116162433f490a7bb54d30b52",
-        "dest": "nuget-sources",
-        "dest-filename": "zlib.net-mutliplatform.1.0.8.nupkg"
-    }
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/asynckeyedlock/7.0.2/asynckeyedlock.7.0.2.nupkg",
+    "sha512": "3531c49506ca4166791bc4a394d00690c35c52a5ffa1f0946bc02cf9ead793f82f933a6c90ec85ddd67e97723ca56da998cf3a586cbb75db1fe39bbe64b479c7",
+    "dest": "nuget-sources",
+    "dest-filename": "asynckeyedlock.7.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/bdinfo/0.8.0/bdinfo.0.8.0.nupkg",
+    "sha512": "b9b3e42e71def59d5150ad4a830f8792b39bfd1964a5c975e509fcd47569cbaaae763da098346f852f90dcd5c82bf9136d3130819d12c1452b2b9f21cad14367",
+    "dest": "nuget-sources",
+    "dest-filename": "bdinfo.0.8.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp/1.3.3/blurhashsharp.1.3.3.nupkg",
+    "sha512": "7a49ff313da159a1aefc91279c77eb7265a52c50118e4b91d2174a225edfaec13051cc49023fdc4c08ce52635bd68d88e1de9c5968d885fc0d5e53934ea96c17",
+    "dest": "nuget-sources",
+    "dest-filename": "blurhashsharp.1.3.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/blurhashsharp.skiasharp/1.3.3/blurhashsharp.skiasharp.1.3.3.nupkg",
+    "sha512": "f17106411b69a58580e0854a662d44623445e96866d6cf8834865ff978dd1f08ab5646632f35799ed53f56d13d5624efa0e44f60bf10b116c0459c41bc9b2fad",
+    "dest": "nuget-sources",
+    "dest-filename": "blurhashsharp.skiasharp.1.3.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.9.1/commandlineparser.2.9.1.nupkg",
+    "sha512": "4f364e45c9668c7e7cc6a922b488f3fa523033c20d7a432694f0a6af05ce528ea0481d8375e2f4f1032c6990347b4803ce9a0e48068c6fe15ec46fb1254f085d",
+    "dest": "nuget-sources",
+    "dest-filename": "commandlineparser.2.9.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/diacritics/3.3.29/diacritics.3.3.29.nupkg",
+    "sha512": "48d53debccd23a0cea558199f19e26313db0d56f5e65cd9b5866b2c4bc9ccd2273088be9528eba504b43aefdcbc44f2fa54ae175e2c8e5fcbec04fef92be5382",
+    "dest": "nuget-sources",
+    "dest-filename": "diacritics.3.3.29.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.core/0.16.13/discutils.core.0.16.13.nupkg",
+    "sha512": "637e7448e43b8f022858b88073b9a10a937af6878846734ca19eee56af7d0f66a09aec007948eb50b16fc09c78b5526c38773487e956d906566d66459551c47b",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.core.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.iso9660/0.16.13/discutils.iso9660.0.16.13.nupkg",
+    "sha512": "6c9e2c62e2e25c119da650d5991375618f61d7935856a19ddef1f5626ccdff7ada3b32443e03272cf1ee68f384d29759d677dc182f8b9377bc7fddbbc4778998",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.iso9660.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.streams/0.16.13/discutils.streams.0.16.13.nupkg",
+    "sha512": "81fe953b957867ebd9922c55713d1700ee9857345df63c565ab8ba8a3253929fc111fcf477494b6a713f615465aa62f55b17f4f651baae20e59296fe4af27696",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.streams.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/discutils.udf/0.16.13/discutils.udf.0.16.13.nupkg",
+    "sha512": "cf8a49baae53e46515eabb53250e2d8d12956cffc61ce38c25abeafcde84b39b1d8e87b4ae9bcbb6293ac46e06743148bb312ed0f2ac649f1ce6c32c20fcfeb6",
+    "dest": "nuget-sources",
+    "dest-filename": "discutils.udf.0.16.13.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/dotnet.glob/3.1.3/dotnet.glob.3.1.3.nupkg",
+    "sha512": "9a3ffb310bf2a3383d869a6347c3578cc7c02318caeefcef73c4343d3b15592054f483840ea0d024e537edde6c63630ad5a90c5d8d3a41ef67f8033003dc3a92",
+    "dest": "nuget-sources",
+    "dest-filename": "dotnet.glob.3.1.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/excss/4.2.3/excss.4.2.3.nupkg",
+    "sha512": "fcb06d04937a6bd864060e8bdf4a65970c7450cdbdd3279465851310ac8bf12b645cac54ce8b7a8039c7ca9309ba3d9ee4e23827599479c4140f7755e119caa9",
+    "dest": "nuget-sources",
+    "dest-filename": "excss.4.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.3/harfbuzzsharp.7.3.0.3.nupkg",
+    "sha512": "bed625c58228c404f860fb3e247fb6ca3209c93fea62da498ba43419500bd40944b2e117f50f587f860101a6c6478ad1d18075f655376d1749d238d74b6a0bd3",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.3/harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg",
+    "sha512": "cf94e5693c4c475a702c342163f1ee28d2d9c3a13939a8334bb7133d13ffc5ed95d9dbb6145e7ac004cfd6e626a16280df7f1a4c7e3687569eced58b8890a1b5",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.3/harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg",
+    "sha512": "a6dac2eb2c536f25734e5358aaae9263f568871fa31169e816d8617c5b6e933d78e2956ea9e01ac37e0022bf243e63124956804b46f6a0d00826aa02320ef22b",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.3/harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg",
+    "sha512": "dd940d3b3085996b4e5961a0e42bb1a86daad360e3377602fafd60b0cb4d3d5ed9c3f4293a8551df75f38111b3a9f4dbbea4cb27b3e0632a6d48239b606d13c9",
+    "dest": "nuget-sources",
+    "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/humanizer.core/2.14.1/humanizer.core.2.14.1.nupkg",
+    "sha512": "cb3a8653f1ca34b67d52fafa92f49cdf0615fd2e4efc8be4948516e5617b32e8af18b63cc12e486672cf92dec3d4a5bc12dd849e5d08dcbce0daf196336e17b3",
+    "dest": "nuget-sources",
+    "dest-filename": "humanizer.core.2.14.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/icu4n/60.1.0-alpha.356/icu4n.60.1.0-alpha.356.nupkg",
+    "sha512": "f043fff5f139070ff84d2ec0397c2fb571ced6fcf37e2161f68406e9df03b86daa12fbe12a977f6e9f6f1a9bf46de5792d83fd82e4a2c395b3201aa2a846bc90",
+    "dest": "nuget-sources",
+    "dest-filename": "icu4n.60.1.0-alpha.356.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/icu4n.transliterator/60.1.0-alpha.356/icu4n.transliterator.60.1.0-alpha.356.nupkg",
+    "sha512": "1d6552fb8125793b391626ac930075b0db7903041e79bb43394cb75d767ff9c749c83099d73136366773a802ccf4b7537aff21e7c4b7f668e272511f7107af5c",
+    "dest": "nuget-sources",
+    "dest-filename": "icu4n.transliterator.60.1.0-alpha.356.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/idisposableanalyzers/4.0.8/idisposableanalyzers.4.0.8.nupkg",
+    "sha512": "86f93bc4c501c14cd4b0668bebacc54ec380a75ee12a3d973b4634acd230b6cde26743c617533a613005890d2d1a7271cec03ca167337376537dac63f755f07f",
+    "dest": "nuget-sources",
+    "dest-filename": "idisposableanalyzers.4.0.8.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/j2n/2.0.0/j2n.2.0.0.nupkg",
+    "sha512": "7b1fd8117c9608ec5a8502eb604760aaa81b3e490725b0d3fd055f2523053f2e6b9ddf15fb1101dff091949fe92da17a1130a2d295e328ee1a7a3e41a40833c4",
+    "dest": "nuget-sources",
+    "dest-filename": "j2n.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/jellyfin.xmltv/10.8.0/jellyfin.xmltv.10.8.0.nupkg",
+    "sha512": "b1ef253f878f7abb158268b78f29df7240998c63f4f1a94d60486c408abd8ec976b3572a1a0c1c1a149cb7ff4c6a048fc1ae9102c51b556aeddd7bed2e19e1d9",
+    "dest": "nuget-sources",
+    "dest-filename": "jellyfin.xmltv.10.8.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/libse/4.0.8/libse.4.0.8.nupkg",
+    "sha512": "2eb6eb3ae07d746fe8d19c9ae13d086e5f02483024a1accb5ad0e5162d894ff4cc24d430b42bffd75873a7eebe884bb6aa7ab351c4d1e77fea00e3840df9d352",
+    "dest": "nuget-sources",
+    "dest-filename": "libse.4.0.8.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/lrcparser/2024.728.2/lrcparser.2024.728.2.nupkg",
+    "sha512": "d1b27a7e33788e6b29f39a374962eb0ad9276524333cc526528bd53ffd35f14a95071667f6721925a12788b85c1bc458246f2ca76470af2bcd1811a0e4dc0c34",
+    "dest": "nuget-sources",
+    "dest-filename": "lrcparser.2024.728.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common/3.0.0/metabrainz.common.3.0.0.nupkg",
+    "sha512": "01350da82a7dc0ada18e726e15dff30e499491c0807a3fcb4cea5247c38a3c24d0afa34751e12b605cbd86143372e86e2f5b997cb08d1f42bb6dbfbcf67ddea3",
+    "dest": "nuget-sources",
+    "dest-filename": "metabrainz.common.3.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.common.json/6.0.2/metabrainz.common.json.6.0.2.nupkg",
+    "sha512": "fa333a0227d1afe406960695b3c8ff8492112dd3a5e58027db63f84dfbd7122756e74af821f506c5137c08e3fa9c363177c3246375ce85acf358d35f961feb94",
+    "dest": "nuget-sources",
+    "dest-filename": "metabrainz.common.json.6.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/metabrainz.musicbrainz/6.1.0/metabrainz.musicbrainz.6.1.0.nupkg",
+    "sha512": "b36824dcbe668234e0974464122140717586b6d4ad881bc3e90d3bddca624f7982de3684e65f1571dd6cd3632e3c7edf6ac9de82a9c82b33a95df223541982e3",
+    "dest": "nuget-sources",
+    "dest-filename": "metabrainz.musicbrainz.6.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.11/microsoft.aspnetcore.app.runtime.linux-x64.8.0.11.nupkg",
+    "sha512": "5373c5f77dc775544b72d4994101cac0618ca885518a44b928cd888086f9287f73a17af3642a6b017242beb6500e83ad68a3a7f9ebb217e832ebd0af781fa03b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.authorization/8.0.11/microsoft.aspnetcore.authorization.8.0.11.nupkg",
+    "sha512": "4f310a03a421ba8100430881ed34fedb75b10e3c6845bcf97cddc6927884e341778399b3bdee4c4fc1b4e5ea91a5f4cbe70da746d7f4efae092a71d41b97dd52",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.aspnetcore.authorization.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.metadata/8.0.11/microsoft.aspnetcore.metadata.8.0.11.nupkg",
+    "sha512": "d37a9d96f337e62d71c82ea63685553011039d2e940ca2b4f5690a15cabd4e0e84e1c66a59a5b429dfb221efc577937b6421b672a9e4e6ffdc69ea4bef0f9b61",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.aspnetcore.metadata.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/6.0.0/microsoft.bcl.asyncinterfaces.6.0.0.nupkg",
+    "sha512": "221a05a0c910f7a87b620d8f3831ed392b4eb95d112bee274d35f27009ad2a26445de9d7cd235fe6fb4a03f2550874bda3be3dddd96edaf9c0852a9c23d7b099",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.3/microsoft.codeanalysis.analyzers.3.3.3.nupkg",
+    "sha512": "0d4896db8aff9d731c5b1c8f73a4b37460c3f08080fbeac0ecf169abf5bdff9c9a994778f453816b888e939d9d0d615245c91a2e4ba31f85d2ea8de222767104",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.analyzers.3.3.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.bannedapianalyzers/3.3.4/microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg",
+    "sha512": "0b8e5e7aa98142864edd0073512f11c899f9b5aad535012726477cc1189de63252895a829c7ffc5730d09e5df8a6db7ccd9d0c6a17007bc94ca0ca5a36e04042",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.bannedapianalyzers.3.3.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/4.5.0/microsoft.codeanalysis.common.4.5.0.nupkg",
+    "sha512": "61f1aa2061217670fab3e1043e5068b72aed43907866195c693211407e2b3ebd6cd9762ed0b3e9ef06965a33d3ce3fb09c88f3c900ad32feb0485922575a41e3",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.common.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/4.5.0/microsoft.codeanalysis.csharp.4.5.0.nupkg",
+    "sha512": "68d7df26baf9362ec2cabb3543d1f7a570b0f345053a23e8feeb5317c50ba392825bafb1710ebee5c929e762e749782fd11eaadb3b437224ebfccba08b985fcf",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.csharp.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.workspaces/4.5.0/microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg",
+    "sha512": "474703fc47639e146aca623e2c15734c173167789e28bc2e46f65b8691d86c6db4e94723c469e2cea3ebd1f8395f816ad119350b91a88e95b6706db6ff977148",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.csharp.workspaces.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.workspaces.common/4.5.0/microsoft.codeanalysis.workspaces.common.4.5.0.nupkg",
+    "sha512": "66f89952c90fac37702c0df2d04fbe8561768578baa0aa30a947220b253c952e109f4bb79c852bd471c16ad3957593db6a6e5e468994472f6210d742e6a4757f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.codeanalysis.workspaces.common.4.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite/8.0.11/microsoft.data.sqlite.8.0.11.nupkg",
+    "sha512": "57374540586b0da9b6ae53ae4bea10faa84cc33850653366b4fd115783cadc8e4e999e8df9c54976a47a787dac6d71a44f527ed879a2182539ad80b64b445091",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.data.sqlite.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite.core/8.0.11/microsoft.data.sqlite.core.8.0.11.nupkg",
+    "sha512": "81efb4b0feaa97d67502645a4385d8c6a11e3b4e2bb1db3f2211ce2a7e9c703fd9f342126cdd328ff12dcf08be1cbd1478cc134bdf19da5237efc6dff46ab83d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.data.sqlite.core.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore/8.0.11/microsoft.entityframeworkcore.8.0.11.nupkg",
+    "sha512": "cf5d52c7f5d689cace47117d72ff5fef566fd8390006af8001df649bee0a3196ec381b00880db9b83926c5b8a559f7fd397dcb5db15c19e37b7a11bd04b91cd9",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.abstractions/8.0.11/microsoft.entityframeworkcore.abstractions.8.0.11.nupkg",
+    "sha512": "64080c34faacc6cd5831101c8b2245a58c3403ac0b1b5f6b4319ef3f5213673c606cedf541230c599714c49d19e88aba36bdbd4f6281e4db84d4f2c532d6afb7",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.abstractions.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.analyzers/8.0.11/microsoft.entityframeworkcore.analyzers.8.0.11.nupkg",
+    "sha512": "dfb27bfc753587d6f7c6c518bfc3743ed2ee1e35c048a9e0d2512b916f7f3ccc616248760bc780d7217097e3ee076048c24bb2e488b7722576438adff776a83f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.analyzers.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.design/8.0.11/microsoft.entityframeworkcore.design.8.0.11.nupkg",
+    "sha512": "2599c8a3081e8936ebdcea6f090c3611deadbbac48da95f84d922a9fd329d5399337752b2a1381240339f1656e43c4032619b70866dc58a2fbf835c2c2e9e255",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.design.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.relational/8.0.11/microsoft.entityframeworkcore.relational.8.0.11.nupkg",
+    "sha512": "6bf9071342ba151e8da4a28e9cbca2f4a15391c6d4d8e35e281224dfa7baa5b31bb5af34099d37ed3de92dec2aa98b8c80226b852a0fc794bc482ce106c70b1c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.relational.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite/8.0.11/microsoft.entityframeworkcore.sqlite.8.0.11.nupkg",
+    "sha512": "bd6cf8b7574693c262f9fa2c7cfdd59e4cf30999fb5bf6477151934a19dbfb21f94ecb8c9f1b1b9d1a3d3f6e70b541855d37f8c277ff30357edeedaef2dbfb18",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.sqlite.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.sqlite.core/8.0.11/microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg",
+    "sha512": "798a06456c660e67bc1e3a2c1049249fe2ce70d3317615ca353562220f7e7e8bff0db2e36b0f392e1e931765084dcd9229c6954c053a04f6b87ae9f2d1f88c75",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.sqlite.core.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.entityframeworkcore.tools/8.0.11/microsoft.entityframeworkcore.tools.8.0.11.nupkg",
+    "sha512": "1ad3b75bed1d444b631b344c9f0bc186d14863ecf8988233e52b53cc7e825e58fd61d5d6e38b2a623b3ee7a307d6f2900fec902a1c6aad0669ba3ea3391d0561",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.entityframeworkcore.tools.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.apidescription.server/3.0.0/microsoft.extensions.apidescription.server.3.0.0.nupkg",
+    "sha512": "0935055d9b547f1feb24c9777a9d44dca03bb2218311d9b541103c724adb7a5b447ebf87b390dbcadb9380f05ffcacacb2fd3ad738f285cb25f70dcb24c6ab9b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.apidescription.server.3.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/2.0.0/microsoft.extensions.caching.abstractions.2.0.0.nupkg",
+    "sha512": "fc1f7d3f267d86ce18ba04aeebce36b4047f5a7c3cb2342a4209d3c0f1b0fa2f07ce70ea82a85442e9c9a54ec3102d63e5b88098a3f7c08468a835fb51fb423e",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.abstractions.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.abstractions/8.0.0/microsoft.extensions.caching.abstractions.8.0.0.nupkg",
+    "sha512": "1fdc30912cc1ead9362f70853de219a9dc7070bc28f621e387185670e605746ee2f13b0df9db03d0b1f8919d4bdaad40ebe9f8203e3a0cbb61145aa8848be136",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/2.0.0/microsoft.extensions.caching.memory.2.0.0.nupkg",
+    "sha512": "2b46b6dca1b37f2b45c4001f7c52c5195fe2d488f32e2658bf025a1772c875a04555e84991385bf50d51536f6c2d53e16c8e23253da07a52f95d23e15f1a6bd3",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.memory.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.caching.memory/8.0.1/microsoft.extensions.caching.memory.8.0.1.nupkg",
+    "sha512": "39d053a5a92f413d012f910df6716cdac2f1cacfd234531b956dfcd10f1a83ea8cb84d017d4c72e011f87c53db27e33e9dc7c86f842eacdb1907cb895b448817",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.caching.memory.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/3.1.0/microsoft.extensions.configuration.3.1.0.nupkg",
+    "sha512": "314056d5e02a6d57b1f2ad1b9c2c59d27a7326d88a08c5b938758a08162d49c9b227e89354ff4fbfa47d2679c5d1463e3eca489033cd5eaa38a71422fc757ecb",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/8.0.0/microsoft.extensions.configuration.8.0.0.nupkg",
+    "sha512": "da48a8ef3b4cd2a6beb78008382d9fccdcdd42ff3a71d9efc5ac69d4020421294ac95b07cf11520341a69ee241925cd040d49a382df243e2fa194f6896ef9734",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/3.1.0/microsoft.extensions.configuration.abstractions.3.1.0.nupkg",
+    "sha512": "13ebe935f71a5447ecf5729d177816dbc00b052ed8908c7371f62aef3510614031f6279e694d6ea3baed141c91645568c98290e9445d6278db2455e28136d1d6",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/8.0.0/microsoft.extensions.configuration.abstractions.8.0.0.nupkg",
+    "sha512": "3316170910a94290c8df4fed26fa884a47dd9bf974eb7ad22368d5a63308660a01d2dab4a44662061dacaeccf4ba09cdabfccd4636f76ab3178becec5ad31a2f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/3.1.0/microsoft.extensions.configuration.binder.3.1.0.nupkg",
+    "sha512": "965cc4ee738f92c9059492de62cb6984db69d420d825ffb13bf03793df481aea198a6f343d922807659f5ab07c4e9440ad079dbd78f5898cec25a59a90245a0c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.binder.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.0/microsoft.extensions.configuration.binder.8.0.0.nupkg",
+    "sha512": "9a5931e9d417b8cd4903fe8b94aa8ec07a1f0d43386717be38171a5eb432b1765d7da95e7f092e6997eccf3f4828d5716317a68fcc8fed32f0ad4f1f82bb7223",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.binder.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/8.0.2/microsoft.extensions.configuration.binder.8.0.2.nupkg",
+    "sha512": "63f5d5d0f5df1c7f90a138c75e14d81f3598af78c2c736a7aef5035ffcf9d40ac5a133571935a08290ceb92db72357c8203261165f8f7f057c450b2c611f6c2a",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.binder.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.environmentvariables/8.0.0/microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg",
+    "sha512": "e7e284b1af1362db2ae4ee6df9fff7b4766df63861837fed0019a43388f688158b328b45dc9188ec966bca8e0f1efae0eca9be739b41de24702001942e103db8",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.environmentvariables.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.fileextensions/8.0.1/microsoft.extensions.configuration.fileextensions.8.0.1.nupkg",
+    "sha512": "a9727a08418460a2c66da8ed447cd9ca199157e43e22b84fb0d642cfc4b7b74cb577c3bbd7217b6abc3742fcba7b8e35f873a1a289ee4315c09ce5f1b94ee9a6",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.fileextensions.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.json/8.0.1/microsoft.extensions.configuration.json.8.0.1.nupkg",
+    "sha512": "b61e38d1accfadeae40c670f9414eb360987db39024d0619986733334a63a88aed9727ed8fbccd2fb906f1e37f3b3df8baf01c1cb819b72f452c559f02cab37c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.configuration.json.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/3.1.0/microsoft.extensions.dependencyinjection.3.1.0.nupkg",
+    "sha512": "d1f4b1f75870cba2faf333c7a7e8d3bedbce69424b06840957f3be2e95c13ff43e9bde14d48efb982656f31208997eacae9cb1ba2d54b3ad6d49264bad727cae",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.0/microsoft.extensions.dependencyinjection.8.0.0.nupkg",
+    "sha512": "96391af4ae0542f4ae96c8009c9ffbf304acadf476cda262a8ea73e33b172529541044186c59d656377bb2de42c9f5925e0632a81f6e7516f2a646e8916f16ec",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/8.0.1/microsoft.extensions.dependencyinjection.8.0.1.nupkg",
+    "sha512": "b6d2c496ce68bf91ac7499eb2a8aae34347e648b9be853e535a36044afcf8173561650aba33068346f458062f29c8e0c1f5859f73800d512ec0f464dd467d00f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/2.0.0/microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg",
+    "sha512": "54deb3578c6430a23120fe3c910cd789e64f59751e18bdccd6742f8170a6e38100be2d9e0b48188ff95dadf3dd7b8245dd33b2a4010d66fb895f5aa44c50207b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/3.1.0/microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg",
+    "sha512": "e184edffadaca3c7782695c8d291ebdabb42bd1b67a0764355c6ce9a186f8d186de36924288eab3978d07318f3aeb6f14e1a883d6f69f8e69a1948486a3ae577",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.0/microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg",
+    "sha512": "94bc05ed29755109565d9cdfc901087ee1fa08302dda393106bc9a0bd7384f0dc2b6c2f123c1bd53fce06babdbfa845dc6d22a163c4b0646c5251dcc5aeac282",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.2/microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg",
+    "sha512": "ba1960ef110ac7387a2a06eefc02c59ce57b0fe58b3e0cccb79b1c8f2150105c5d1f4b65e0ed95ff50d70f28142917c6a735b83f4e5406bb1d8f9dd1f9635d7d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/8.0.2/microsoft.extensions.dependencymodel.8.0.2.nupkg",
+    "sha512": "42a9e54c51b5f99a1d26ae79ce21accb5218a600b2534632aa2c2a4cdcac5d2942d2976f2c915fe8523ec5e390043607ac6b0a530de9e7cbbad9e1841ecea37e",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.dependencymodel.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics/8.0.1/microsoft.extensions.diagnostics.8.0.1.nupkg",
+    "sha512": "a668c7de32c39384a0dcf85abb12560b2e286441ae269b39efea7149bb2e4a90a8949d6f941b9e24b8b3642f15f86b8a968f36183d97695019bd23f0ea7be237",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.0/microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg",
+    "sha512": "a75dd040e3e03e90c8baa006bd569db9fd09983cf9c27bfcb246d96a73e2595cea7aee6116438989f8df31b56bc7fe6adaa7a7fcb6ab95ec5b1d64d0b17ff617",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/8.0.1/microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg",
+    "sha512": "267c18ce804b572b17d9256b41c544428c5586c144a6815f864408f08ada786ec8ec239bb7a89d985571ad3e962fdc4a059511439db4936c0bdbd660bf002f46",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.abstractions.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/8.0.11/microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg",
+    "sha512": "b93febd5e681c26766d890feb34d1062ce66d44b84d1103f8c1d4a80ed0964ded8ef2551fd6bcfeab1d95fd8c5922733448954bece46d96c781b9ae984a08ef5",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.healthchecks.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.abstractions/8.0.11/microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg",
+    "sha512": "0499640470c8390fee1a1fbc7a34efd4ef65f3ac93fe871420b6c844805e7711e6c98a9f3b1e9f1d8f598a247ef6d14e9dcdf3b442f31a65fd64a93ef3f64680",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.healthchecks.abstractions.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore/8.0.11/microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg",
+    "sha512": "962e83a815dd873648d722b9aa791298a6a6f1e82c11787f369babaa59fe45eef088f9556ec1e99a8ad9a18078339de3892dafbce4ed444d9e7a4d4e85135a7c",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.diagnostics.healthchecks.entityframeworkcore.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.abstractions/8.0.0/microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg",
+    "sha512": "fe9aa18f2e819694f20e322c93e075e27bee2d57ddd5380624fc48a95669c526c270ab5c74f58c6a4721d18ecdb5b2febf0315f8794585ae65617831459e2a0b",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.fileproviders.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.fileproviders.physical/8.0.0/microsoft.extensions.fileproviders.physical.8.0.0.nupkg",
+    "sha512": "7612261a35b76d0b3a337ab262de57c3b605e8a1e55bf4d47f15e374e5577ab2ce4ae370980ef2c1335c4e323e6adcfe3718eee86570ac6e4ff5cb100450331f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.fileproviders.physical.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.filesystemglobbing/8.0.0/microsoft.extensions.filesystemglobbing.8.0.0.nupkg",
+    "sha512": "23a5e50cf695ba18c7a77f7c050e40d6fb065957480db17f5e75e5cf269c8f50763c996c28d0dcfca09e2c1248540898ab53c474cadc705548f5fe491dd263fd",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.filesystemglobbing.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.0/microsoft.extensions.hosting.abstractions.8.0.0.nupkg",
+    "sha512": "6788c16c139ba241cf2c65e4ded10b8ad8b38602b4490a5ff27dd52b02c90083b7cd40c7b4fac48aed94742f6545da959870b5d889b41078b22708acd761da66",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.hosting.abstractions/8.0.1/microsoft.extensions.hosting.abstractions.8.0.1.nupkg",
+    "sha512": "4c7ef392ffc0c10a17b3bbc1232954fac16ed7e7e51aaaefd1e68f63eb19ca0b409f991bb72b4a1f9e7ecd241f196e579a2a740017cfe08b64c75062d60508e9",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.hosting.abstractions.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/3.1.0/microsoft.extensions.http.3.1.0.nupkg",
+    "sha512": "7692b3ada00fff278826bede064e734889b0af77cc4a8f2865d40d2e7b437319b5f418abb1383717cc69aba94ea0c65de0c2683d52e3a10b788675e63bb72d21",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.http.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/8.0.1/microsoft.extensions.http.8.0.1.nupkg",
+    "sha512": "296bd0a65e3591df63d64e987c781c32fa677a08c84fe2911e6288eae94b1c77dd2a134692b5bfdcac93a4992fa14b69bbb81cfe3a1e7ff2e90d5babe917ec71",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.http.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/3.1.0/microsoft.extensions.logging.3.1.0.nupkg",
+    "sha512": "fd20e13f2908b212746f0b87df684bb3ca3599f40ceb72b7813be343b7dbef4d6865dd83c370d9ff719f88366f4998cefa481222e926db27dacc2493b610d415",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.8.0.0.nupkg",
+    "sha512": "aa30576c428dff69bac5f5d71721af6c4ef583bc524edbd0a94b49cbd80f698905021260e1a432c32e6d48ce5a30f6822c209f11dcf7c819aba1fa8347925b06",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.1/microsoft.extensions.logging.8.0.1.nupkg",
+    "sha512": "ab3363c4e103963ee5013ada55fddcd771961e48e5124f41e70589e589dacf27d20cff7e04bfc214db79fd937cbad80e99cef565f72e0cc10b84d9b3ac0619fd",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/3.1.0/microsoft.extensions.logging.abstractions.3.1.0.nupkg",
+    "sha512": "303b2749a54bbe683506e8981c39e3c3a9f76a08bc6eb9bd7ca7204079c6a88c68191a5247656e8c9138633be1a7758205b3bab92fca4a1e3a774b96315e6a63",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.abstractions.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.0/microsoft.extensions.logging.abstractions.8.0.0.nupkg",
+    "sha512": "50a0add96d30d90580fb8e02a25cea0aa15f4d22744279b5acfe18cc8568b74402aa062d5db13cc5887a08bfd24e07cbc88b2fc10ee8eec2c37edf3bcda7f8a7",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.abstractions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.2/microsoft.extensions.logging.abstractions.8.0.2.nupkg",
+    "sha512": "f8b9df3fa7b837cb5f2fa53a86bfd47279f81bc332db55b8bb7ea14f55dfe2158f351d35199c0cc0e01c735f394ded2a3a8f1c85c3ff6ea1c3ab785bfbf362fd",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.logging.abstractions.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.objectpool/7.0.0/microsoft.extensions.objectpool.7.0.0.nupkg",
+    "sha512": "ee96a7f7ddda2557def993082c7d7429c25135b37b80df916f0427ee1349778722f10bd284810482662dee5c2f011fdb00e188626e7cde5c10c4b8718fef6639",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.objectpool.7.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/2.0.0/microsoft.extensions.options.2.0.0.nupkg",
+    "sha512": "afc8ef803afe1d832eb86f023bbbd5dc14b76583ce191338dfb2f7ff030adcec71d35aac194d4efcf0d08e5af572e2205e848fc137f8812f8ca85bde72e11e33",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/3.1.0/microsoft.extensions.options.3.1.0.nupkg",
+    "sha512": "643aac9c2d8d0aba135f9259d56d89a5d6b760723c694fd10a2ad3c8da291f535f27e94a733fbd7f80f208b1fd98ac6b5980c6546a3a1093eab40d7bfd617a9f",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.0/microsoft.extensions.options.8.0.0.nupkg",
+    "sha512": "1c004082a132e7b75a0c95acef3578a4d5db42c55e0996e40b95b663e9a83c5a20ed481a85db7567fff7e3de3dbba6a7d4fe5c825dc7ce95de956689afa16c5a",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/8.0.2/microsoft.extensions.options.8.0.2.nupkg",
+    "sha512": "cc0c10336580c9519740a042b1e42d391bcb32b63732163ae1161e1c5b55a4cd4a736e1902eb2a4dbb89d784b0acf584b5042b4f3481a61dd30a4e229fb523c5",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.8.0.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/8.0.0/microsoft.extensions.options.configurationextensions.8.0.0.nupkg",
+    "sha512": "5c32ae67ae4e873216bbbec15554778e0acbebc283862a2debcb11a995c42a5fd75f9436c8da421aa51bc5c12db4e6c4e82f12da1ff942bc5a6e1a8cf3c77a7d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.options.configurationextensions.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/2.0.0/microsoft.extensions.primitives.2.0.0.nupkg",
+    "sha512": "47284b149a0cb337dbbb5af3fe0ce8aaf3ab760b275f193407f3387ca8ec25d6fafc8dedd8c755ab8b35756b3c84e5ca8dcab6ea8bec2cbd543cba304ec69371",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.primitives.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/3.1.0/microsoft.extensions.primitives.3.1.0.nupkg",
+    "sha512": "abd8306bc481c1aa6ac016576e2be6be4332037af80dae407896727684e799d5147af2fff39a05f5be3e864391d5753897b7f35d8c57fc7221f5c4783e002ce5",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.primitives.3.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/8.0.0/microsoft.extensions.primitives.8.0.0.nupkg",
+    "sha512": "1f5475ca3d3ce18463456dd135afac502d6f82fea6e4e4814a61f86616c348decf28b73d15c2bb276d1a3c039ea6064f75e1329f6f3a64caa3520d70ab92c32d",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.extensions.primitives.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.11/microsoft.netcore.app.runtime.linux-x64.8.0.11.nupkg",
+    "sha512": "810ca3d4ab581a01495939f8b533356c7e31bd3c95ca4e692c26191e591899f5f0a35a0356f2eb5e2382deb29d1f103e73cb5178f26c3432102880252659a002",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.11.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
+    "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.1/microsoft.netcore.platforms.1.1.1.nupkg",
+    "sha512": "9835090f578b5c8ce6527582cd69663506460e9fdc5464fc2b287331c24d9369e57dd1543a865a8bd89d4fcfc569c26bf0dbfcce102675fdfd1479b9a9652819",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.platforms.1.1.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
+    "sha512": "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.platforms.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
+    "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.openapi/1.2.3/microsoft.openapi.1.2.3.nupkg",
+    "sha512": "9d8710a99c1a976014c0a4a837d021fa58fd13d5c1d573861e357c43ab1b4ea73ea85cf72afab0a3dfa5738908ade7ef6904e2d280ffff2ad9cfc8868c228461",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.openapi.1.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
+    "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
+    "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.win32.registry.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/8.0.0/microsoft.win32.systemevents.8.0.0.nupkg",
+    "sha512": "25016c508653fbf463c52d8fc3d2773b7c211c2402c4ea7b4aa987fb29c851d3f80c5e7abbcace2d4d5e061ae290524e8029afbc49a37d7e5186fe06aa4609b2",
+    "dest": "nuget-sources",
+    "dest-filename": "microsoft.win32.systemevents.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/mimetypes/2.4.0/mimetypes.2.4.0.nupkg",
+    "sha512": "3d25e35d5e893dff932db404e2d9151be7da8e1cffe213d7689199dc81b337472e24fb6517db5fbb481f05676abd0b367f2e8ddc8b6a97af4dd6a273531e514e",
+    "dest": "nuget-sources",
+    "dest-filename": "mimetypes.2.4.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/mono.nat/3.0.4/mono.nat.3.0.4.nupkg",
+    "sha512": "b2909720dc40cd459741e4ad9af16cf8289dd43f5fe1f90a28f26937da8d8ec4621d3b296019a94bfe5c871ef12b41f49dc85c415e656d5376a3b1fa48d63973",
+    "dest": "nuget-sources",
+    "dest-filename": "mono.nat.3.0.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/mono.texttemplating/2.2.1/mono.texttemplating.2.2.1.nupkg",
+    "sha512": "22627ee103feee11c04c4eefb33b3ff874cd5553c71a4287266465b3bedf9803d27bb998ce736c9b977f79b436a168823a9d33637183ce466470c098187acb6f",
+    "dest": "nuget-sources",
+    "dest-filename": "mono.texttemplating.2.2.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/nebml/0.11.0/nebml.0.11.0.nupkg",
+    "sha512": "07dc3630b81d5e4a29be8df8178d6fba6f7bf20396bb5217af2941b741d88764e0a91e8d524249a9a94dbe8dfd5f128e4d8556e71404d63b521a493a8ccd9965",
+    "dest": "nuget-sources",
+    "dest-filename": "nebml.0.11.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
+    "sha512": "99b252bc77d1c5f5f7b51fd4ea7d5653e9961d7b3061cf9207f8643a9c7cc9965eebc84d6467f2989bb4723b1a244915cc232a78f894e8b748ca882a7c89fb92",
+    "dest": "nuget-sources",
+    "dest-filename": "newtonsoft.json.13.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/playlistsnet/1.4.1/playlistsnet.1.4.1.nupkg",
+    "sha512": "903c52d34062831b99a6d632f175e22e9afb247ae3618bfce8018b0595784264f0dbb0b63bf139d65dc8e34efdf15bce9e7608af1a8dee87765523193f85a850",
+    "dest": "nuget-sources",
+    "dest-filename": "playlistsnet.1.4.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/3.1.2/prometheus-net.3.1.2.nupkg",
+    "sha512": "140f9817fc9da297eeea6b7b6d03303d53364268bbda89cf76f56b37692c94c6fa160c2d0d475fc1d07857a64f21b0c7202178a5aaa0e64048254b6a0a439ad9",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.3.1.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net/8.2.1/prometheus-net.8.2.1.nupkg",
+    "sha512": "f7094a591be84d1b8171081cc0c30e8ee4d2adb9118eb52fb53830f789de29960e86e17278dd44da439b5e463151fd7602dbf5bdab838c2b4626812b3d2a4ccc",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.8.2.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.aspnetcore/8.2.1/prometheus-net.aspnetcore.8.2.1.nupkg",
+    "sha512": "3ab7a9556aabfb429f87478b6e7e4eaed4445832189c670a245e8c77349946c6c2b278f30e6bfaa9ee9a5412789b300a70d96d5cf5d5f1b42b996f70e9660ffc",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.aspnetcore.8.2.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/prometheus-net.dotnetruntime/4.4.1/prometheus-net.dotnetruntime.4.4.1.nupkg",
+    "sha512": "62712e2d734722927f6ee382dc4341efd0267549197dafa300e57692d40b46e7640d12c14452c0a9d298bc497b2831354fa531403ef64a0c8a187f1f98d951c5",
+    "dest": "nuget-sources",
+    "dest-filename": "prometheus-net.dotnetruntime.4.4.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
+    "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
+    "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
+    "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
+    "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
+    "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
+    "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
+    "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
+    "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.0/runtime.any.system.runtime.4.3.0.nupkg",
+    "sha512": "bfee3c68312296860e5459af5e770c2e9fcd4ac134361fd569a9ce1e6574b9ae3978aad403f89639a4b5bac8ee5bb0ee1b8edb819e9a60f13ca5bd1812889bbd",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.runtime.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
+    "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
+    "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
+    "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
+    "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
+    "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "8f071552ee042f0cba39b1ba0a1205cf73de447d662995bae68f857a5946f7d154c029a79e37469081675687873c8bf2b9efe57f5cbd660c366b1ca51823f7f2",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "a135ca0f4f5a49319b5a52b7f4338f8a5fc4387edf26f29e6cbf63a3c3a37b2b5c51c9caf562ec41e470fba281060362465bc56915be782d6c75778aa6195e46",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "2f24e2cba88a96bb23848e1404878e4478a65642387b7b76aa4007587fe7c4d8208cbde53d3ed65f8d0d71cd688bfc16be66dc5f7bcf84c7b2ccf1b3c505b0b4",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
+    "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
+    "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+    "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.2/runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "a34ad2dbe67efcae97fcbea57af386b30660a98ab8229a56c0dca241316e673cf7a26e19c6efb6b7117cc271fdf208741ba6f8447ae254c91acba3ddb7d2923a",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "ce0873e07000df98e640bd265e969d4a9236535cee2699c5363f3ab297557b0d756260557995f2ee163cff05fc2ba922d66ba0e4cb28521f841e7d546ab3b63e",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "bf754c1a66cd70dc1bd38d54fe675e9dd470417ebba62e2f79e278be8f06cc3496ff58ed90d30b5dd4d3efea9accbd09eb17cd87be882951c0fdfb833c371f70",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+    "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "cd4b7ba744de80086521ab67cad2db3085d488388d3d9cb83d9946389f0f4c784539bf3a4ffb8d4f3347c5c7813aadef95b355fd2563e30c948a883c27b95287",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "d7fc28a9f600e471edce0989c01c485d4e2a7e99551f531413afa75039a4004d4e2c27e88976d65432635a321d86316a3c6cdaebc7b2fefa42141b64f4f10d66",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+    "sha512": "5fe0e6a878eff59cfe24a8d57af51140576d8e0fec4988e4892c233c47b3a3eed27dec072a6c0d55dd615777cd9ce3fe545c5353b4a95289376ad0b9408ed4be",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
+    "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
+    "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
+    "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
+    "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.0/runtime.unix.system.private.uri.4.3.0.nupkg",
+    "sha512": "203ebe272791d79ab0c40afe9d0543852ee91b9fb4ae5bc15524d97728bc8bc9d7e0cbcf65d1fab8cfb0aa7a4ae37e7938933eef127aa5ea46f60e57b6ad2d91",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.private.uri.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.0/runtime.unix.system.runtime.extensions.4.3.0.nupkg",
+    "sha512": "54b81784c08e934389c59e6e155af6b1855e4bbc41678b01a702c94e6daba87c6ddfd16fe9e2cb61f3097bfa4950dbc37781454d027ce5ba6c50a393cc91b888",
+    "dest": "nuget-sources",
+    "dest-filename": "runtime.unix.system.runtime.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog/3.1.1/serilog.3.1.1.nupkg",
+    "sha512": "02985d43db0efd5e56b086e0a29af986de381a163a8633ab81a88b6620a3df380afc4506366beba0f214ac8ec37c8d435bdf130285dcde331b14733e62fab8c7",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.3.1.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.0.0/serilog.4.0.0.nupkg",
+    "sha512": "1f6279bcfa93ca9c13180dd7c7e5944d5351358b9cd3a360cbbf12f2dda508700cb9ffadeffd4dfe772a6ddb2c029e2c3473e655a3b660a644de51d67133268c",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.4.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog/4.1.0/serilog.4.1.0.nupkg",
+    "sha512": "4b0bcbc6ef35b4d1914dc870f3ecafc4a7e320b66842f8fce03d733874fd4d171885343c91e43dd1d5e49f55c50f948cf6c681c64819a8632187309ff82be15a",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.4.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.aspnetcore/8.0.3/serilog.aspnetcore.8.0.3.nupkg",
+    "sha512": "d46d53d19ea7c1c00eab3064fc995ca7d455df983355490d4053a5bb6e51164f74e007d4cdf1ed20de7c85b19bb65507f61645f2c3472cc386fe244230bd5f4a",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.aspnetcore.8.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.enrichers.thread/4.0.0/serilog.enrichers.thread.4.0.0.nupkg",
+    "sha512": "d776603c04a031634dfeb64203e3ed4204eb96d503ac8183d5ba231259c55cd4411359116164271e38ddb949a9c4604f4946021c52c34044cda85797e6b4a7c2",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.enrichers.thread.4.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.hosting/8.0.0/serilog.extensions.hosting.8.0.0.nupkg",
+    "sha512": "580cd1e3c1099bb8774504409e59cca246dc1e5754cc6a0e2085ca03c4ecaf66088e284d854c235578db3d0a449a854015454b686c0bbb1c299ac9c052e14a6d",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.extensions.hosting.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.extensions.logging/8.0.0/serilog.extensions.logging.8.0.0.nupkg",
+    "sha512": "cbe725d5313d4cbfe551ba20b6686ea02c17a6572b79170d312b3e31e3763b544276de387bfadd98bf623d602aabd5c6fcd131a2a29dbf7204c649a86d1cd8f1",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.extensions.logging.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.formatting.compact/2.0.0/serilog.formatting.compact.2.0.0.nupkg",
+    "sha512": "a4a87b075d4dea0f3d481669206a6488890e5f4e5615be587b9d4c74ff0b8bea260fa19e85610ef24ce2ce7af49cd561f4e2212769559352aac9325a234462ee",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.formatting.compact.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.settings.configuration/8.0.4/serilog.settings.configuration.8.0.4.nupkg",
+    "sha512": "04f71c87368908aa672326229cb5286cc14565124f539b2d19e4524a50bacbac9b4686c0cad52c8f0324e288f13620e0154a7b64d5abbd176a100b33ca32cc73",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.settings.configuration.8.0.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.async/2.1.0/serilog.sinks.async.2.1.0.nupkg",
+    "sha512": "04c6181f987cf459d96ffafca2a7cb7d5bef0f5b079277deb5ac009d238929ff8b075b2e73504330505462d76652ce106966dd3a0407c8799bfe5d0bec7f0fdd",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.async.2.1.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/6.0.0/serilog.sinks.console.6.0.0.nupkg",
+    "sha512": "49c6a20f42a9b46d8cccd76d287e92210aeb967d8f8daf93be82561fa050d91f927d0bb5ea81a147caa899b9abf47b616e5d74a8cfcffeadc1545da0b73a979c",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.console.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.debug/2.0.0/serilog.sinks.debug.2.0.0.nupkg",
+    "sha512": "fbddb39441be29aee4077c487e321ab0c3a167adc74f698115a5412d989e4d33c2a8d1cd9fcb96b312c567cb293d23f8431c936d9647691e019600a405c5cc6d",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.debug.2.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/6.0.0/serilog.sinks.file.6.0.0.nupkg",
+    "sha512": "90daa5403374597318b8973f4a7725dd14d44425a75793c82baa4143aeb3b4aeb8423636edd2b3b82a9df367d4e42339e73baaf62d42c87e7d4a958fa4394609",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.file.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.graylog/3.1.1/serilog.sinks.graylog.3.1.1.nupkg",
+    "sha512": "4509679ad467ca5c96344e08ed507684acce267d31865c3057bf1eed88fa2b66f9fd85d142669dc2fbc891ed82a04fc45d82aeb65d0ff2f4a4903fde37926470",
+    "dest": "nuget-sources",
+    "dest-filename": "serilog.sinks.graylog.3.1.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/seriloganalyzer/0.15.0/seriloganalyzer.0.15.0.nupkg",
+    "sha512": "c0ddb69f4e0ae258ceb8ce7ee6923b6aa6f815246a347684832fb7c08f9af696435a11986b73b2f9325138bd3da0932681127e166102f6a6b92943bd0c0e3e06",
+    "dest": "nuget-sources",
+    "dest-filename": "seriloganalyzer.0.15.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/2.0.0.1/shimskiasharp.2.0.0.1.nupkg",
+    "sha512": "babb41bfc0354dea0b52cc70ea9e9510204e33b0a8f544ceffacfaa919bc7ba26a24493ee70fb5a30758320380e4d88163a7daee0f663602db0365956eb7c0d1",
+    "dest": "nuget-sources",
+    "dest-filename": "shimskiasharp.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.9/skiasharp.2.88.9.nupkg",
+    "sha512": "3a2ffa5e05f45cdb80e6735ee947e91e08ff145fc50c7882e75d44b6ae0c2cd733420d15b6a4274a186b3a79d463a1273e27ff7fd79a51d0937251ebb6ef761d",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.9/skiasharp.harfbuzz.2.88.9.nupkg",
+    "sha512": "7ebc75df46b3d2bfb110324dc0613fb1395667219ce42c757fb98f0ff60b755fc69fe6bb94613a2be854e8feecdebe671ea46cd9e8a0df2e90ff7d461ab123cf",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.harfbuzz.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.9/skiasharp.nativeassets.linux.2.88.9.nupkg",
+    "sha512": "5c6a3e93a18e70e6adcd548bd2f76fa311114346ce4d812e520f250d33342d5ad8d05ea285433bd15cb19bbc48d9bbf2ef7d1f1725dd71705accefaba3f46892",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.nativeassets.linux.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.9/skiasharp.nativeassets.macos.2.88.9.nupkg",
+    "sha512": "74cfb865746f2911935290bfb92469b331e50415d5abeda87598ebdb4049c52af84a5daeda41ebcb0bbaec6a7debb42d83cdc6c9f61cea55d43c720a78c3ebce",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.nativeassets.macos.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.9/skiasharp.nativeassets.win32.2.88.9.nupkg",
+    "sha512": "d18bd8194041c7ffb79302d4f1be584e8c024e88b12cb4669a738cae551da3d3e3924087bb0aa42d34a9003cfb35037d73637894e67d02223d100a1b4215eeec",
+    "dest": "nuget-sources",
+    "dest-filename": "skiasharp.nativeassets.win32.2.88.9.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/smartanalyzers.multithreadinganalyzer/1.1.31/smartanalyzers.multithreadinganalyzer.1.1.31.nupkg",
+    "sha512": "0e703633c4e989fd218620ec76a21bbbd9dce34f313ea1dda8d698be11ffaf08d959b8e2d9c964aa661e7dff3611003504c757ce8cc956d8626fa2ab21c482fb",
+    "dest": "nuget-sources",
+    "dest-filename": "smartanalyzers.multithreadinganalyzer.1.1.31.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.bundle_e_sqlite3/2.1.6/sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg",
+    "sha512": "69169044def48e943aac624d83be72ae09b046b7f4bac1efcd2aebbe02fa9847ad8bc5303b05834b39880c05e33ce64a51a34f5887a13bbc35761d72ce086baf",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.bundle_e_sqlite3.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.core/2.1.6/sqlitepclraw.core.2.1.6.nupkg",
+    "sha512": "16bc39cd5325dea37e1564fc328a35966d6d820878290d945dc57496b716d4935b534285989af32fa7bd25ef9a8ac795b63e6a19044d3f84a104d643319473be",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.core.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.lib.e_sqlite3/2.1.6/sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg",
+    "sha512": "69543fcac6af6520b638ed00c5f8f8dc59747376382c561ca82904780214b3e75cc4293106c4a3f6f671b73d591195800c44afa2d4dc533a8257b00fdf77d663",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.lib.e_sqlite3.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.provider.e_sqlite3/2.1.6/sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg",
+    "sha512": "527cec74f2ebeff238b3bb1f898637576659537aa6f2c5a4384b1c1b094cb772bfe86f05c13a1020247bd73fed8759c0bf568a1c0059c1d87bbbed2db1018701",
+    "dest": "nuget-sources",
+    "dest-filename": "sqlitepclraw.provider.e_sqlite3.2.1.6.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers/1.2.0-beta.556/stylecop.analyzers.1.2.0-beta.556.nupkg",
+    "sha512": "08163f6061ebc26ea9b8069a82e9f575d656a50f1d9299eda874f4107731eb2e02b512f201f1c34c6983d92baecd6ee5e992aa6b61c78ae9490a7fddbdd51882",
+    "dest": "nuget-sources",
+    "dest-filename": "stylecop.analyzers.1.2.0-beta.556.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/stylecop.analyzers.unstable/1.2.0.556/stylecop.analyzers.unstable.1.2.0.556.nupkg",
+    "sha512": "0e9fbae713d2d30690bb331e7308a619894ee26c13798855ec0a2529b32468d67fbcf2bc1f02aa0f3ae7e6851d2b595684ef415245aa8119b9b1b7d58c30916b",
+    "dest": "nuget-sources",
+    "dest-filename": "stylecop.analyzers.unstable.1.2.0.556.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/2.0.0.1/svg.custom.2.0.0.1.nupkg",
+    "sha512": "0ccdaba6b38665c31d2e660a5983a980584a7ebb1a999d91cd3acfa3861f68a428a663f3fdf24093bed52f7628b9d2ea020a1ab6614d846c6c8a2515b90b2312",
+    "dest": "nuget-sources",
+    "dest-filename": "svg.custom.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/svg.model/2.0.0.1/svg.model.2.0.0.1.nupkg",
+    "sha512": "a02226f89e5c5ce81b49a1a38bda8945f070849fcc557fcf3ad2f500430c0e1410ee542681fc8b7a2d560c4bc00a084f58f96f001ded0ad94254d1e2d05fba67",
+    "dest": "nuget-sources",
+    "dest-filename": "svg.model.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/2.0.0.1/svg.skia.2.0.0.1.nupkg",
+    "sha512": "eec0ec97de78aca75af5aa5523df5afefdf7a9cdcea0379669d001a82b4fa3a3882a82614b4ab25c6436a48c9834d3d1e19e669fe32d1396d4c8bb6c712a94ad",
+    "dest": "nuget-sources",
+    "dest-filename": "svg.skia.2.0.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore/6.2.3/swashbuckle.aspnetcore.6.2.3.nupkg",
+    "sha512": "3e491d5f00e2ea8c26170ed72c0ab670beb3d8178baff82a4aa8e97986791f65125c62a73e413d5d6b435ca2205e2bbe92d6e542a504a7ad2cce552eb3548f93",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.redoc/6.5.0/swashbuckle.aspnetcore.redoc.6.5.0.nupkg",
+    "sha512": "0a2d7427dd148741e5761818cf9a920b198fa235304abc00310b56dbb94147734adbadd7c0a3fcfcc32b1443609b248842e8611849c0a3f56419a4b3007f1488",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.redoc.6.5.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swagger/6.2.3/swashbuckle.aspnetcore.swagger.6.2.3.nupkg",
+    "sha512": "c12fd032b76e9cbc4697b3bae1f123807410e3d5a8eaf3558a1840880f8bd30fa5dc4b316e86575310eb6eec1924467e0c9c02631afb10e20ec9eead6da3f439",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.swagger.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggergen/6.2.3/swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg",
+    "sha512": "777f7ac29a52dd45bdcbc4a2f426e12f5f8918b9d7e018b4cb8c8f26cb2f40bec77378c9cff23a951170559a9ef4b24a25ab2a3a2ddff63a30cec9240e535912",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.swaggergen.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/swashbuckle.aspnetcore.swaggerui/6.2.3/swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg",
+    "sha512": "90e6aafa82fbdcacba8b48a2f59bcb6418a5ecab7e7d659b44ce8d8bc5a3aa97ee168e85a971e8d4cc5d78e3e1f9e2a5cd0e9e4da09cd8d32f898eca4f74b397",
+    "dest": "nuget-sources",
+    "dest-filename": "swashbuckle.aspnetcore.swaggerui.6.2.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
+    "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
+    "dest": "nuget-sources",
+    "dest-filename": "system.buffers.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.codedom/4.4.0/system.codedom.4.4.0.nupkg",
+    "sha512": "13f96f49f3053ed35f94081d33a02e3d4f096d976a752a06a54eba1bb4ab76e0aa76b1723df95aaaa57880dd9dd21ac2069bbdd876a8aa950fe5dfa0f48b5cc7",
+    "dest": "nuget-sources",
+    "dest-filename": "system.codedom.4.4.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
+    "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
+    "dest": "nuget-sources",
+    "dest-filename": "system.collections.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
+    "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
+    "dest": "nuget-sources",
+    "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/6.0.0/system.collections.immutable.6.0.0.nupkg",
+    "sha512": "f8036412e384c5c5af6d28f4eab2543207d2ebbb16c47b70f6c471bc5aa4b9f44404c47d776d295191f20a89caa898abd73a2304dcaf77979174ced2d9160169",
+    "dest": "nuget-sources",
+    "dest-filename": "system.collections.immutable.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition/6.0.0/system.composition.6.0.0.nupkg",
+    "sha512": "48618297e7fcf02b05bce032bcde1882be780e0e6d156b8312855f2a2d080ff590fd7bcc7a296ebddec9d82f654d9286e42b424ce07b112a449be2bfb29bcb8c",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.attributedmodel/6.0.0/system.composition.attributedmodel.6.0.0.nupkg",
+    "sha512": "a53c30b3cfeb4fc67741e85305707b324481a6ac394fb1af71acda01309c090557424a4352135effe0dc37c2953634441994328d89c22532d8fdf8eb7f717405",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.attributedmodel.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.convention/6.0.0/system.composition.convention.6.0.0.nupkg",
+    "sha512": "f4dd753fa196325d1a5e9a06874e88d9651f812f48b013608efe322e079ba194bdf4587603bcd71a86e33f53103c48b1dc8f1776842d5dfb4afbd7e8b4e9dd02",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.convention.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.hosting/6.0.0/system.composition.hosting.6.0.0.nupkg",
+    "sha512": "5a5a331c91f12b6cb63c5dfbea1095980a0a0bfa5d9e336c7316245706f6bedafd76a0b6880ca2c79415f31840c231730285b9bcc3b9474659a28ac9fdabd03b",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.hosting.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.runtime/6.0.0/system.composition.runtime.6.0.0.nupkg",
+    "sha512": "ccf6d0fa4a8bb6a170121281728e965df4d346a69c55e0ecefab6b8241959876de568462b7d5dbd290aa6e510cbf1973802466e99b59a7e95b92889052acd79f",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.runtime.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.composition.typedparts/6.0.0/system.composition.typedparts.6.0.0.nupkg",
+    "sha512": "8cf43d8d159dc065c04ad9ec09a60ff431a2fe5fb3d4821c04a02a11687ede9bbc900d82f6d4d6f5d298895c664afbe0e6982b63a20059c5884bdb8c265793b7",
+    "dest": "nuget-sources",
+    "dest-filename": "system.composition.typedparts.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
+    "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
+    "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/8.0.0/system.diagnostics.diagnosticsource.8.0.0.nupkg",
+    "sha512": "86e32c62e9773dba192a63bff0e2ffcd57826ed1123c9261fa8c9229f9d1dc26962b3740fb025f6ad5c139162575a6c493b213a9ef3fc1747d15ca0edd0c5878",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.diagnosticsource.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
+    "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
+    "dest": "nuget-sources",
+    "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/8.0.8/system.drawing.common.8.0.8.nupkg",
+    "sha512": "318e393b68d144d12d3a41de0dbdaba6796c7be03bb70ead38b5ee7f5581fe059ce78fb39cf4d8e45f1c8ecd194a4b38ff20fd034beeb79a56bfd6a8e33eab52",
+    "dest": "nuget-sources",
+    "dest-filename": "system.drawing.common.8.0.8.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
+    "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
+    "dest": "nuget-sources",
+    "dest-filename": "system.globalization.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
+    "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
+    "dest": "nuget-sources",
+    "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
+    "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
+    "dest": "nuget-sources",
+    "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
+    "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
+    "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.filesystem.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
+    "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.3/system.io.pipelines.6.0.3.nupkg",
+    "sha512": "a72246cbe26c5a7ec098f69798063076731529a3b2e555a3d41692ef5496222328d3988cfbd8e23a54e474f5429df3e478537f85e0dbc145d2cf3c263dbe726e",
+    "dest": "nuget-sources",
+    "dest-filename": "system.io.pipelines.6.0.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
+    "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
+    "dest": "nuget-sources",
+    "dest-filename": "system.linq.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.linq.async/6.0.1/system.linq.async.6.0.1.nupkg",
+    "sha512": "792b7b14a6fcc52f88cc0475a2ba8a694399393fa602446fe23fa6d39d782c16f908b4bc3acd58454554932b7a41056d84424b5fd66f0fe6e3c00178eb3d8a1a",
+    "dest": "nuget-sources",
+    "dest-filename": "system.linq.async.6.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
+    "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
+    "dest": "nuget-sources",
+    "dest-filename": "system.memory.4.5.3.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.4/system.net.http.4.3.4.nupkg",
+    "sha512": "163edeef734d1f0a1ff7b8053d326eabc82fe86f3de72c6466dd780d59d974487882f2a5f16ae4b02c0d8c8a7f25e617ff2bbfab133f88ebfd6a2f99637169ed",
+    "dest": "nuget-sources",
+    "dest-filename": "system.net.http.4.3.4.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
+    "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
+    "dest": "nuget-sources",
+    "dest-filename": "system.net.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.0/system.private.uri.4.3.0.nupkg",
+    "sha512": "5989a57ef273b689a663e961a0fe09d9b1d88438e5478358efc4b165de3b2674fa9579c301ce12d2d2fa5f33295f2acb42eceea2ebebf70c733da6364ceaf94d",
+    "dest": "nuget-sources",
+    "dest-filename": "system.private.uri.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
+    "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
+    "dest": "nuget-sources",
+    "dest-filename": "system.reflection.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/6.0.1/system.reflection.metadata.6.0.1.nupkg",
+    "sha512": "7ae13917018aee2c9074db134aaa27cad2d71072f7d80bb13dc16b1de16cec62503b064914d12d86326534c9ed29dbbaed5fcdab7f88b620ae1d1c5022b4673b",
+    "dest": "nuget-sources",
+    "dest-filename": "system.reflection.metadata.6.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
+    "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
+    "dest": "nuget-sources",
+    "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
+    "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
+    "dest": "nuget-sources",
+    "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
+    "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.4.0/system.runtime.compilerservices.unsafe.4.4.0.nupkg",
+    "sha512": "d03f39b62f48714c56aa5db5ddde1613e7f62633734731e611a1b7e2a880de10fb1bc3b88b4320afe46eb649f8a66adbad6f80058e2fce910280799dc3ebd38d",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.compilerservices.unsafe.4.4.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
+    "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
+    "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg",
+    "sha512": "0a5baf1dd554bf9e01bcb4ce082cb26ee82b783364feb47cba730faeecd70edc528efad0394dcce11f37d7f9507f8608f15629ebaf051906bfd3513e46af0f11",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.handles.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
+    "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
+    "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
+    "dest": "nuget-sources",
+    "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/5.0.0/system.security.accesscontrol.5.0.0.nupkg",
+    "sha512": "ae6b03ad029d3eb6818a6c8bb56cf4904013fa535a67b8e621b783a029dd88aa2e471e002cbc7d720381ad8bc8c6b93111a08f6ce2d271af6d974bf4d02b6c81",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.accesscontrol.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
+    "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
+    "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
+    "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
+    "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
+    "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
+    "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
+    "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/5.0.0/system.security.principal.windows.5.0.0.nupkg",
+    "sha512": "44a920aaaf22b2172d41319bb57ab2b8e1a4531d5f02192a6f53a81d875125195b60ba0b5a44a45981d137fd7b0f3a65b12959b5fd97afc0578cd84ef27467cd",
+    "dest": "nuget-sources",
+    "dest-filename": "system.security.principal.windows.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg",
+    "sha512": "6ff7feec7313a7121f795ec7d376e4b8728c17294219fafdfd4ea078f9df1455b4685f0b3962c3810098e95d68594a8392c0b799d36ec8284cd6fcbd4cfe2c67",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/6.0.0/system.text.encoding.codepages.6.0.0.nupkg",
+    "sha512": "ec873a95ec517de2c5a5364ada30974ddd5e0fafef2ad2517609a1900b5059d35757536fd073805001fa68d5b56a3d4647010a96c9eb233b1d172a3b45fbe4a9",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.codepages.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.8.0.0.nupkg",
+    "sha512": "77dadf6b1a73eeefb50507a6d76f5e3a20e0ae7d3f550c349265ae4e0d55f0ae4f0ef1b41be08dd810798a8e01dbba74e2caac746b5158b8e23d722523d473ed",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.codepages.8.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
+    "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/8.0.5/system.text.json.8.0.5.nupkg",
+    "sha512": "13589021ae3e81f54c877abf613ce931cc24ca57bf127af1063ccc1eb4dc57a6cc223a61e6452207f5d0dce453b6627430e31e4143c78e71e9b5dd647f680abf",
+    "dest": "nuget-sources",
+    "dest-filename": "system.text.json.8.0.5.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg",
+    "sha512": "97a2751bdce69faaf9c54f834a9fd5c60c7a786faa52f420769828dbc9b5804c1f3721ba1ea945ea1d844835d909810f9e782c9a44d0faaecccb230c4cd95a88",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading.channels/6.0.0/system.threading.channels.6.0.0.nupkg",
+    "sha512": "32adff895c57ab9ef864cf89660403f041b07841be7c44a0c3c2c8451a1da076a8c1b4dcf1c993b585304ad7549afa408a0f797ad6814d0f14eb748a1fc9ce03",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.channels.6.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg",
+    "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.tasks.4.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/8.0.1/system.threading.tasks.dataflow.8.0.1.nupkg",
+    "sha512": "24622fd7d5e33cb55309d0dd35616aa3d6e7aa0c66e1e597c0ca6106cb26cc4248349815139c8f00a51e062506f5fa5f6cffeaa6fe8cb030c64b1d6952224ab1",
+    "dest": "nuget-sources",
+    "dest-filename": "system.threading.tasks.dataflow.8.0.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/taglibsharp/2.3.0/taglibsharp.2.3.0.nupkg",
+    "sha512": "9be37f6431f6ead36babe78dc6527340d7b4b0fe444736aaeae5aef3651191d4e0421d9d671106aea544888695d7841000fb12f8a44aab1b5fe93fb7c90d983f",
+    "dest": "nuget-sources",
+    "dest-filename": "taglibsharp.2.3.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/tmdblib/2.2.0/tmdblib.2.2.0.nupkg",
+    "sha512": "ad0cb6ad203d1ce0f0f2f9f96140326abc0fc54e7b79e38846f6d3431e5c0f17bbe689cd52059931f52f258b16a2ce55fb9f7b2c7ca6b800542fcaf257a2774f",
+    "dest": "nuget-sources",
+    "dest-filename": "tmdblib.2.2.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/ude.netstandard/1.2.0/ude.netstandard.1.2.0.nupkg",
+    "sha512": "29c5e5a43cd2a0a9dc770ac3ec9976c5ef922622d114bb12cfde950f58d45fbd385e013d170df6fa2d45f9c56d29738bb4240b4f1c3a0e3908d9f99ff938c3c0",
+    "dest": "nuget-sources",
+    "dest-filename": "ude.netstandard.1.2.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/utf.unknown/2.5.1/utf.unknown.2.5.1.nupkg",
+    "sha512": "342b4a01af4cfb0a0b77de0afd7c6393fafc124e72b420ff1f7936891aa259e6a55129d46e54eb5d7fce9759a6ab52ebec89045fcffb23148324ebaa7b604629",
+    "dest": "nuget-sources",
+    "dest-filename": "utf.unknown.2.5.1.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/z440.atl.core/6.8.0/z440.atl.core.6.8.0.nupkg",
+    "sha512": "e52cd9acbe0eba1c72c6d2967a314198421e029ca0271e4872f37044549173d3403f33e2d391350356c96772938d1fa95ba9c914b238b3929d3c9293469c3fd5",
+    "dest": "nuget-sources",
+    "dest-filename": "z440.atl.core.6.8.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/zlib.net-mutliplatform/1.0.8/zlib.net-mutliplatform.1.0.8.nupkg",
+    "sha512": "c329dc559df3eb4b4bf2f832f37442af6d1be625c97a904f25bc4078684e4716d769ee2c1215329e78a299ec0f6c8a90d6ed1e3116162433f490a7bb54d30b52",
+    "dest": "nuget-sources",
+    "dest-filename": "zlib.net-mutliplatform.1.0.8.nupkg"
+  }
 ]

--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -2,6 +2,7 @@ id: org.jellyfin.JellyfinServer
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
+# NOTE: Modifying data here might break yq in regenerate-sources.yml
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet8
   - org.freedesktop.Sdk.Extension.node22
@@ -811,6 +812,7 @@ modules:
       - type: git
         url: https://github.com/jellyfin/jellyfin.git
         commit: b3e563385c1ae8e07caff508ae59ab2518682989
+        # NOTE: Modifying data here might break yq in regenerate-sources.yml -- yq fetches the tag from the last module
         tag: v10.10.3
         x-checker-data:
           is-main-source: true


### PR DESCRIPTION
- Resolve action-lint and zizmor findings
- Add notes about yq in regenerate-sources to manifest
- Install yq if necessary, is usually pre-installed
- Utilize prettier to reformat sources and reduce noise
- Check upstream tags