### PR TITLE
Clean up various old comments in the manifest ✨

### DIFF
--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -125,9 +125,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^intel-mediasdk-([\d.]+)$
-          # Version from https://github.com/flathub/fr.handbrake.ghb.Plugin.IntelMediaSDK
-          #versions:
-          #  =: 22.6.5
       - type: patch
         path: data/intel-mediasdk-gcc13.patch
   - name: onevpl
@@ -284,9 +281,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
-          # Known newer versions.
-          #versions:
-          #  - '!=': v2025.4
       - type: git
         url: https://github.com/KhronosGroup/SPIRV-Tools.git
         dest: third_party/spirv-tools
@@ -306,9 +300,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^vulkan-sdk-([\d.]+)$
-          # Known newer versions.
-          #versions:
-          #  - '!=': 1.4.304.0
       - type: git
         url: https://github.com/KhronosGroup/glslang.git
         dest: third_party/glslang
@@ -317,20 +308,14 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^vulkan-sdk-([\d.]+)$
-          # Known newer versions.
-          #versions:
-          #  - '!=': 1.4.304.0
   - name: libplacebo
     buildsystem: meson
     config-opts:
       - --buildtype=release
       - --default-library=shared
       - -Dvulkan=enabled
-      # NOTE: It seems this option was disabled before 10.10.
-      # - -Dvk-proc-addr=disabled
       - -Dvk-proc-addr=enabled
       - -Dvulkan-registry=${FLATPAK_DEST}/share/vulkan/registry/vk.xml
-      #
       - -Dshaderc=enabled
       - -Dglslang=disabled
       - -Ddemos=false
@@ -356,9 +341,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^vulkan-sdk-([\d.]+)$
-          # Known newer versions.
-          #versions:
-          #  - '!=': 1.4.304.0
       # Already included as a submodule: glad, jinja, markupsafe
   - name: numactl
     rm-configure: true
@@ -383,10 +365,6 @@ modules:
     sources:
       - type: git
         url: https://code.videolan.org/videolan/x264.git
-        #mirror-urls:
-        #  - https://github.com/jpsdr/x264
-        # NOTE: Unoffical, repo has tags.
-        # - https://github.com/ShiftMediaProject/x264.git
         commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
         #branch: master
         #tag: 0.164.r3194
@@ -560,9 +538,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/FFmpeg/nv-codec-headers.git
-        ## Deprecated property since 2025 June
-        #mirror-urls:
-        #  - https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
         tag: n13.0.19.0
         commit: e844e5b26f46bb77479f063029595293aa8f812d
         x-checker-data:
@@ -655,9 +630,6 @@ modules:
             x-checker-data:
               type: git
               tag-pattern: ^debian/([\d.]+)-1$
-              # Known newer versions.
-              #versions:
-              #  - '!=': 1.4.304.0
       - name: volk
         buildsystem: cmake-ninja
         config-opts:
@@ -671,11 +643,7 @@ modules:
             x-checker-data:
               type: git
               tag-pattern: ^debian/([\d.]+)-1$
-              # Known newer versions.
-              #versions:
-              #  - '!=': 1.4.304.0
   - name: jellyfin-ffmpeg
-    disabled: false
     build-options:
       append-path: /usr/lib/sdk/llvm21/bin
       prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
@@ -768,7 +736,6 @@ modules:
         commands:
           - cat debian/patches/*.patch | patch -Np1 -d .
   - name: jellyfin-web
-    disabled: false
     buildsystem: simple
     build-options:
       append-path: /usr/lib/sdk/node22/bin
@@ -790,7 +757,6 @@ modules:
           versions:
             <: v10.12.0
   - name: jellyfin
-    disabled: false
     buildsystem: simple
     build-options:
       append-ld-library-path: /usr/lib/sdk/dotnet9/lib


### PR DESCRIPTION
Just some small cleanup of various old comments I came across in the manifest.

- Remove deprecated, commented out `mirror-urls` entries
  - https://github.com/flathub/org.jellyfin.JellyfinServer/commit/c4a7f75e65c11bc86b784c2e550529eec00f22d1
  - https://github.com/flathub/org.jellyfin.JellyfinServer/commit/513623264d420b6ec57538a4d65c537a1b9c6bc0 
- Remove outdated "Known newer versions" comments
  - All currently used versions are newer than or the same as the versions mentioned in the comments.
- Remove outdated comments
  - `IntelMediaSDK` comment is about older version than the one currently used.
  - `Dvk-proc-addr` comment is about it being disabled but in fact it is enabled.
- Remove `disabled: false` comments as such is default behavior