### PR TITLE
Upgrade Freedesktop SDK/runtime from 24.08 to 25.08

### DIFF
--- a/nuget-generated-sources-arm64.json
+++ b/nuget-generated-sources-arm64.json
@@ -204,10 +204,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/9.0.13/microsoft.aspnetcore.app.runtime.linux-arm64.9.0.13.nupkg",
-    "sha512": "bce6f7066351808842174ef047a6e2bde326b18134edf9a5c0a05573333bc553a0c7d85634851253ab69c1b90be0bbd4f87df4da7616b68641237b5f22ea2863",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/9.0.14/microsoft.aspnetcore.app.runtime.linux-arm64.9.0.14.nupkg",
+    "sha512": "bca8da41530fdfdbc1cf70a43a92482d5cb3f8072db057b4c84be60ce6b5117751e9a0949297eaf3d89c9e54855abfe889ccfd87118afdc3908129d15ccd93f1",
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.9.0.13.nupkg"
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.9.0.14.nupkg"
   },
   {
     "type": "file",
@@ -708,17 +708,17 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/9.0.13/microsoft.netcore.app.host.linux-arm64.9.0.13.nupkg",
-    "sha512": "4790857b9653f550b9d81626d5a5d99b17498ed626a562308f4ffcdb7c678d78a58416de6ffb764831d3db11723416c311c8f837972402c451d246080a8ea263",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/9.0.14/microsoft.netcore.app.host.linux-arm64.9.0.14.nupkg",
+    "sha512": "1b11c52abce5439ee660c3d72626716e827fad211e72f42099fbdd83b7c09c3edcf3f244d0076885ba1878279b4043c0395d91d3011fdcba00094a92dffdb2ed",
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.host.linux-arm64.9.0.13.nupkg"
+    "dest-filename": "microsoft.netcore.app.host.linux-arm64.9.0.14.nupkg"
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/9.0.13/microsoft.netcore.app.runtime.linux-arm64.9.0.13.nupkg",
-    "sha512": "ea3daddd7c3879fa2a5f8012a8f5745132f3742162d54ac67b593cf6b38368c36e8062b31f4a56ad65604235550319e47977d32d14194c9d92f9796f174b7147",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/9.0.14/microsoft.netcore.app.runtime.linux-arm64.9.0.14.nupkg",
+    "sha512": "0262eb279b411303cad5530f764e15cb767afbec8691a2f96e92b01a963d4942fcc7a9f042359f63ceec9ce2bdf57f0d11796dc49368bcfd059112c28be66bda",
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.9.0.13.nupkg"
+    "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.9.0.14.nupkg"
   },
   {
     "type": "file",

--- a/nuget-generated-sources-x64.json
+++ b/nuget-generated-sources-x64.json
@@ -204,10 +204,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.13/microsoft.aspnetcore.app.runtime.linux-x64.9.0.13.nupkg",
-    "sha512": "e4079fe2a5b5c3f976c9577e97d2cc5e7fe1c46b809b0abfc81520bab23bdde707aee2236c94ded504d61c1fc3e328c43d8a339ad0f53d4f82c0e5b1a27f7089",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.14/microsoft.aspnetcore.app.runtime.linux-x64.9.0.14.nupkg",
+    "sha512": "8d877ee4a354cdda37eb2b5cd4bcf84e501e1e144d31742bddc741cd802a0b1f707ec3949ea3ccdb89f1ed736f36bc9ac328cf89c6dd3f6c2234181d425b6cec",
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.13.nupkg"
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.14.nupkg"
   },
   {
     "type": "file",
@@ -708,10 +708,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.13/microsoft.netcore.app.runtime.linux-x64.9.0.13.nupkg",
-    "sha512": "eacd72683690da0f8084e4b2c63974abf5ca808cc7a51470c31441a1891684d20bb7e1ce4039edc7a294130d1e28ebe0124f64726d135268ddec9b4f08a543bf",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.14/microsoft.netcore.app.runtime.linux-x64.9.0.14.nupkg",
+    "sha512": "7fb37fa3a3fdaf12eb7ca272cb2ee9a7fef2b697be08d6bd2ddc963e36014938958bd6c83ead725cae8c3383dec0290bb284b48ce3845a67d81eb61be45c3b54",
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.13.nupkg"
+    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.14.nupkg"
   },
   {
     "type": "file",

--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -202,6 +202,21 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^libopenmpt-([\d.]+)$
+  - name: fdk-aac
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    sources:
+      - type: git
+        url: https://github.com/mstorsjo/fdk-aac.git
+        commit: cac04476081a23c870fed05c36228cd02c5e7c3d
+        tag: v2.0.3
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
   - name: libass
     config-opts:
       - --enable-shared

--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -409,6 +409,8 @@ modules:
             CXX: clang++
           config-opts:
             - -DENABLE_ASSEMBLY=OFF
+      # TODO: Drop once x265 releases proper GCC 15 support.
+      cxxflags: -include cstdint
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_CLI=OFF
@@ -422,8 +424,9 @@ modules:
     sources:
       - type: git
         url: https://bitbucket.org/multicoreware/x265_git.git
-        commit: 1d117bed4747758b51bd2c124d738527e30392cb
-        tag: '4.1'
+        # TODO: Replace with tagged version once one > v4.1 is available.
+        # This is the oldest i.e. closest to v4.1 commit with CMAKE fixes.
+        commit: 78e5ac35c13c5cbccc5933083edceb0d3eaeaa21
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -451,6 +454,8 @@ modules:
                 CXX: clang++
               config-opts:
                 - -DENABLE_ASSEMBLY=OFF
+          # TODO: Drop once x265 releases proper GCC 15 support.
+          cxxflags: -include cstdint
         config-opts:
           - -DCMAKE_BUILD_TYPE=Release
           - -DENABLE_CLI=OFF
@@ -464,8 +469,9 @@ modules:
         sources:
           - type: git
             url: https://bitbucket.org/multicoreware/x265_git.git
-            commit: 1d117bed4747758b51bd2c124d738527e30392cb
-            tag: '4.1'
+            # TODO: Replace with tagged version once one > v4.1 is available.
+            # This is the oldest i.e. closest to v4.1 commit with CMAKE fixes.
+            commit: 78e5ac35c13c5cbccc5933083edceb0d3eaeaa21
             x-checker-data:
               type: git
               tag-pattern: ^([\d.]+)$
@@ -487,6 +493,8 @@ modules:
                 CXX: clang++
               config-opts:
                 - -DENABLE_ASSEMBLY=OFF
+          # TODO: Drop once x265 releases proper GCC 15 support.
+          cxxflags: -include cstdint
         config-opts:
           - -DCMAKE_BUILD_TYPE=Release
           - -DENABLE_CLI=OFF
@@ -501,8 +509,9 @@ modules:
         sources:
           - type: git
             url: https://bitbucket.org/multicoreware/x265_git.git
-            commit: 1d117bed4747758b51bd2c124d738527e30392cb
-            tag: '4.1'
+            # TODO: Replace with tagged version once one > v4.1 is available.
+            # This is the oldest i.e. closest to v4.1 commit with CMAKE fixes.
+            commit: 78e5ac35c13c5cbccc5933083edceb0d3eaeaa21
             x-checker-data:
               type: git
               tag-pattern: ^([\d.]+)$

--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -1,13 +1,13 @@
 id: org.jellyfin.JellyfinServer
 # See https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 # NOTE: Modifying data here might break yq in regenerate-sources.yml
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet9
   - org.freedesktop.Sdk.Extension.node22
-  - org.freedesktop.Sdk.Extension.llvm20
+  - org.freedesktop.Sdk.Extension.llvm21
 separate-locales: false
 command: jellyfin.sh
 cleanup:
@@ -355,8 +355,8 @@ modules:
           config-opts:
             - -DCMAKE_ASM_NASM_FLAGS=-w-macro-params-legacy
         aarch64:
-          append-path: /usr/lib/sdk/llvm20/bin
-          prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
+          append-path: /usr/lib/sdk/llvm21/bin
+          prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
           env:
             CC: clang
             CXX: clang++
@@ -397,8 +397,8 @@ modules:
               config-opts:
                 - -DCMAKE_ASM_NASM_FLAGS=-w-macro-params-legacy
             aarch64:
-              append-path: /usr/lib/sdk/llvm20/bin
-              prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
+              append-path: /usr/lib/sdk/llvm21/bin
+              prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
               env:
                 CC: clang
                 CXX: clang++
@@ -433,8 +433,8 @@ modules:
               config-opts:
                 - -DCMAKE_ASM_NASM_FLAGS=-w-macro-params-legacy
             aarch64:
-              append-path: /usr/lib/sdk/llvm20/bin
-              prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
+              append-path: /usr/lib/sdk/llvm21/bin
+              prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
               env:
                 CC: clang
                 CXX: clang++
@@ -618,8 +618,8 @@ modules:
   - name: jellyfin-ffmpeg
     disabled: false
     build-options:
-      append-path: /usr/lib/sdk/llvm20/bin
-      prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
+      append-path: /usr/lib/sdk/llvm21/bin
+      prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
       arch:
         x86_64:
           config-opts:

--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -24,6 +24,18 @@ cleanup:
   - /share/man
   - /share/pkgconfig
   - /share/vpl/examples
+  # Remove Ruby from final image (Ruby is build-time only)
+  - /bin/bundle
+  - /bin/bundler
+  - /bin/erb
+  - /bin/gem
+  - /bin/irb
+  - /bin/rdoc
+  - /bin/ri
+  - /bin/ruby
+  - /lib/ruby
+  - /lib/libruby*.so*
+  - /share/ri
 finish-args:
   - --device=dri
   - --filesystem=home/Jellyfin Server Media:create
@@ -44,6 +56,26 @@ add-extensions:
     autodelete: true
 modules:
   - shared-modules/linux-audio/fftw3f.json
+  # Inline Ruby for build-time usage as Ruby was removed from 25.08 SDK.
+  # Provides `ruby`, `gem`, etc. which are cleaned up prior to packaging.
+  # YJIT is disabled to avoid Rust dependency.
+  - name: ruby
+    buildsystem: simple
+    builddir: true
+    config-opts: []
+    build-commands:
+      - ./configure --prefix=/app --disable-install-doc --disable-yjit
+      - make -j${FLATPAK_BUILDER_N_JOBS}
+      - make install
+    sources:
+      - type: archive
+        url: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.2.tar.xz
+        sha256: 4618db85bb9ec04d8152d0099db488694a3d3c4f52106625e4ad547f1318db87
+        x-checker-data:
+          type: html
+          url: https://cache.ruby-lang.org/pub/ruby/
+          version-pattern: ruby-(4\.0\.[\d]+)\.tar\.xz
+          url-template: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-$version.tar.xz
   - name: ocl-icd
     build-options:
       arch:


### PR DESCRIPTION
### Description

In short, this PR brings the Jellyfin Flatpak nearly entirely up to date as far as major dependencies are concerned; ~waiting on https://github.com/jellyfin/jellyfin-web/pull/7282 for Node 22 -> 24 upgrade.~ Most prominently upgrades the Freedesktop SDK/runtime from 24.08 to 25.08. ([release notes](https://discourse.flathub.org/t/freedesktop-sdk-25-08-0-released/10399))

### Upgrade issues and resolutions

- Python 3.13/14 changed how `ElementTree` works, broke `libplacebo`, fixed by upgrading to commit with fix
- Runtime 25.08 dropped Ruby, broke `ocl-icd`, fixed by adding Ruby build module (plus cleanup)
- Runtime 25.08 dropped `libfdk-aac`, broke `jellyfin-ffmpeg`, fixed by adding `fdk-aac` build module
- GCC 15 stopped making `uint8_t` and `int32_t` integer types implicitly available, broke `x265`, fixed by `cstdint` build option
- CMake 4.x changed CMake policies and `CMakeLists.txt` usage, broke `x265`, fixed by upgrading to commit with fixes

Upgrades outside of this PR
- https://github.com/flathub/org.jellyfin.JellyfinServer/pull/730
- https://github.com/flathub/org.jellyfin.JellyfinServer/pull/760

Much of the approach has been documented as part of this ongoing build diary comment: https://github.com/flathub/org.jellyfin.JellyfinServer/issues/667#issuecomment-3475397152. In short, I kept `make pkg-x64`-ing and fixing issues as they arose until the whole thing build from scratch without error. Anyway, would love some eyes on all of this as I'm still relatively a Flatpak novice. Though, I do know about Ruby. :sweat_smile: 

### Testing

Did some light testing running the built app on my machine. Everything appears to function fine.
<img width="3840" height="2096" alt="Screenshot From 2025-11-05 16-08-22" src="https://github.com/user-attachments/assets/06f1488f-9321-450e-af64-b74f824bb776" />
<img width="3840" height="2096" alt="Screenshot From 2025-11-05 15-39-46" src="https://github.com/user-attachments/assets/513ed88a-91d7-4fb5-baba-eeef55b4716e" />
<img width="3840" height="2096" alt="Screenshot From 2025-11-05 15-39-32" src="https://github.com/user-attachments/assets/ccd579eb-affc-43b0-85d3-c04942532bad" />
<img width="3840" height="2096" alt="Screenshot From 2025-12-06 13-18-20" src="https://github.com/user-attachments/assets/ad45d555-8b08-43e0-ac90-9843a5e880c8" />
<img width="3840" height="2096" alt="Screenshot From 2025-12-06 13-18-30" src="https://github.com/user-attachments/assets/6238d0e7-c3b9-43d8-92e9-c70861ab8aab" />