### PR TITLE
Remove `mpp` as it's unavailable and remove `rkrga` as it requires `mpp`

### DIFF
--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -313,37 +313,6 @@ modules:
           #versions:
           #  - '!=': 1.4.304.0
       # Already included as a submodule: glad, jinja, markupsafe
-  - name: rkmpp
-    only-arches:
-      - aarch64
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=ON
-      - -DBUILD_TEST=OFF
-    sources:
-      - type: git
-        url: https://github.com/nyanmisaka/mpp.git
-        commit: efab9bc8131d840cf8785f2bb477ae1107ea9e65
-        # NOTE: Not allowed: https://docs.flathub.org/docs/for-app-authors/linter/#module-module_name-source-git-branch
-        #branch: jellyfin-mpp
-  - name: rkrga
-    only-arches:
-      - aarch64
-    buildsystem: meson
-    config-opts:
-      - --libdir=lib
-      - --buildtype=release
-      - --default-library=shared
-      - -Dcpp_args=-fpermissive
-      - -Dlibdrm=false
-      - -Dlibrga_demo=false
-    sources:
-      - type: git
-        url: https://github.com/nyanmisaka/rk-mirrors.git
-        commit: 1d330cc28551943bed3380261a5a9c6fbd58ff53
-        # NOTE: Not allowed: https://docs.flathub.org/docs/for-app-authors/linter/#module-module_name-source-git-branch
-        #branch: jellyfin-rga
   - name: numactl
     rm-configure: true
     cleanup:
@@ -671,8 +640,6 @@ modules:
         aarch64:
           config-opts:
             - --toolchain=hardened
-            - --enable-rkmpp
-            - --enable-rkrga
             - --enable-ffnvcodec
             - --enable-cuda
             - --enable-cuda-llvm


### PR DESCRIPTION
## Description

As the title describes, this PR aims to remove the inclusion and usage of `mpp` as it's no longer available due to DMCA takedown as well as `rkrga` as it depends on `mpp`. ([source](https://github.com/flathub-infra/vorarbeiter/actions/runs/20757666039/job/59604108230))

https://github.com/github/dmca/blob/master/2025/12/2025-12-18-ffmpeg.md

Resolves https://github.com/flathub/org.jellyfin.JellyfinServer/issues/724

## :tophat: :tophat: :tophat:

Removed both dependencies, rebuilt flatpak, installed it, and tested basic functionality. All good.

<img width="3840" height="2096" alt="Screenshot From 2026-01-06 13-09-46" src="https://github.com/user-attachments/assets/4bd48364-1a31-4e5d-ad81-2e03c3cb89d9" />
<img width="3562" height="53" alt="Screenshot From 2026-01-06 13-10-50" src="https://github.com/user-attachments/assets/3b4008ca-dd29-4903-9d3d-a46a8ff82640" />
<img width="3840" height="2096" alt="Screenshot From 2026-01-06 13-10-01" src="https://github.com/user-attachments/assets/3f067825-ac1b-4bf7-be21-b87f92fb5057" />
<img width="3840" height="2096" alt="Screenshot From 2026-01-06 13-10-17" src="https://github.com/user-attachments/assets/3f205e2e-f0f1-41fa-b9f6-58d0badde3ec" />