### PR TITLE
Upgrade .NET from 9 to 10

### DIFF
--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -5,7 +5,7 @@ runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 # NOTE: Modifying data here might break yq in regenerate-sources.yml
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet9
+  - org.freedesktop.Sdk.Extension.dotnet10
   - org.freedesktop.Sdk.Extension.node22
   - org.freedesktop.Sdk.Extension.llvm21
 separate-locales: false
@@ -793,16 +793,12 @@ modules:
     disabled: false
     buildsystem: simple
     build-options:
-      append-ld-library-path: /usr/lib/sdk/dotnet9/lib
-      append-path: /usr/lib/sdk/dotnet9/bin
-      # TODO: Identify if this line is necessary or not. Overlaps with
-      # PKG_CONFIG_PATH. Most other projects in Flathub include it.
-      # com.spacestation14.Launcher and com.github.PintaProject.Pinta do not?
-      #
-      # append-pkg-config-path: /usr/lib/sdk/dotnet9/lib/pkgconfig
+      append-path: "/usr/lib/sdk/dotnet10/bin"
+      append-ld-library-path: "/usr/lib/sdk/dotnet10/lib"
+      prepend-pkg-config-path: "/usr/lib/sdk/dotnet10/lib/pkgconfig"
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
-        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet9/lib/pkgconfig
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
       arch:
         x86_64:
           env:

--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -5,7 +5,7 @@ runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 # NOTE: Modifying data here might break yq in regenerate-sources.yml
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet9
+  - org.freedesktop.Sdk.Extension.dotnet10
   - org.freedesktop.Sdk.Extension.node22
   - org.freedesktop.Sdk.Extension.llvm21
 separate-locales: false
@@ -774,16 +774,12 @@ modules:
     disabled: false
     buildsystem: simple
     build-options:
-      append-ld-library-path: /usr/lib/sdk/dotnet9/lib
-      append-path: /usr/lib/sdk/dotnet9/bin
-      # TODO: Identify if this line is necessary or not. Overlaps with
-      # PKG_CONFIG_PATH. Most other projects in Flathub include it.
-      # com.spacestation14.Launcher and com.github.PintaProject.Pinta do not?
-      #
-      # append-pkg-config-path: /usr/lib/sdk/dotnet9/lib/pkgconfig
+      append-path: "/usr/lib/sdk/dotnet10/bin"
+      append-ld-library-path: "/usr/lib/sdk/dotnet10/lib"
+      prepend-pkg-config-path: "/usr/lib/sdk/dotnet10/lib/pkgconfig"
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
-        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet9/lib/pkgconfig
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
       arch:
         x86_64:
           env:


### PR DESCRIPTION
Proposing we upgrade from .NET 9 to .NET 10. Note, we need to wait until jellyfin cuts a release with .NET 10 support, which has [already been merged](https://github.com/jellyfin/jellyfin/commit/9e480f6efb4bc0e1f0d1323ed7ed5a7208fded99) just not yet released. We'll need to wait for [v12](https://github.com/jellyfin/jellyfin-web/milestone/26) to be released.

References
- https://github.com/flathub/org.freedesktop.Sdk.Extension.dotnet10
- https://learn.microsoft.com/en-ca/dotnet/core/whats-new/dotnet-10/overview

Build failing due to jellyfin's current release pinning to .NET 9 can be seen below.

```console
HEAD is now at 10662e7 Bump version to 10.11.6
Running git lfs checkout
Running: install -D jellyfin.sh $FLATPAK_DEST/bin/jellyfin.sh
Running: install -D jf-backup.sh $FLATPAK_DEST/bin/jf-backup.sh
Running: install -D jf-updater.sh $FLATPAK_DEST/bin/jf-updater.sh
Running: install -D jf-service-setup.sh $FLATPAK_DEST/bin/jf-service-setup.sh
Running: install -D -m 644 flatpak-update.service $FLATPAK_DEST/share/templates/flatpak-update.service
Running: install -D -m 644 flatpak-update.service $FLATPAK_DEST/share/templates/flatpak-update-onactive.service
Running: install -D -m 644 flatpak-update.timer $FLATPAK_DEST/share/templates/flatpak-update.timer
Running: install -D -m 644 flatpak-update-onactive.timer $FLATPAK_DEST/share/templates/flatpak-update-onactive.timer
Running: install -D -m 644 jellyfin.service $FLATPAK_DEST/share/templates/jellyfin.service
Running: install -D $FLATPAK_ID.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml
Running: install -D $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
Running: install -D $FLATPAK_ID.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg
Running: mkdir -p $FLATPAK_DEST/bin
Running: mkdir -p $FLATPAK_DEST/extensions
Running: dotnet publish -c Release --source ./nuget-sources --output="$FLATPAK_DEST/bin" --runtime $RUNTIME -p:DebugSymbols=false -p:DebugType=none --self-contained true Jellyfin.Server/Jellyfin.Server.csproj
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'publish' does not exist or is not a managed .dll or .exe.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 9.0.0
global.json file: /run/build/jellyfin/global.json

Installed SDKs:
10.0.103 [/usr/lib/sdk/dotnet10/lib/sdk]

Install the [9.0.0] .NET SDK or update [/run/build/jellyfin/global.json] to match an installed SDK.

Learn about SDK resolution:
https://aka.ms/dotnet/sdk-not-found
Error: module jellyfin: Child process exited with code 155
make: *** [Makefile:92: pkg-x64] Error 1
```