### PR TITLE
Upgrade build Ruby from 4.0.2 to 4.0.3

### DIFF
--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -69,8 +69,8 @@ modules:
       - make install
     sources:
       - type: archive
-        url: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.2.tar.xz
-        sha256: 4618db85bb9ec04d8152d0099db488694a3d3c4f52106625e4ad547f1318db87
+        url: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.3.tar.xz
+        sha256: 22cf6005d25bbe496b5ebe9224d63a1aaabfbfe02591bb5d612517c5a7836f29
         x-checker-data:
           type: html
           url: https://cache.ruby-lang.org/pub/ruby/


### PR DESCRIPTION
Quick bump of the build Ruby version from 4.0.2 to 4.0.3. Alternatively we can wait to see if a bump PR is auto-opened by `flathubbot` as `x-checker-data` _is_ set up.

https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released/