### PR TITLE
Revamp Ruby build and fix automatic update checking

### DIFF
--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -24,18 +24,6 @@ cleanup:
   - /share/man
   - /share/pkgconfig
   - /share/vpl/examples
-  # Remove Ruby from final image (Ruby is build-time only)
-  - /bin/bundle
-  - /bin/bundler
-  - /bin/erb
-  - /bin/gem
-  - /bin/irb
-  - /bin/rdoc
-  - /bin/ri
-  - /bin/ruby
-  - /lib/ruby
-  - /lib/libruby*.so*
-  - /share/ri
 finish-args:
   - --device=dri
   - --filesystem=home/Jellyfin Server Media:create
@@ -56,26 +44,19 @@ add-extensions:
     autodelete: true
 modules:
   - shared-modules/linux-audio/fftw3f.json
-  # Inline Ruby for build-time usage as Ruby was removed from 25.08 SDK.
-  # Provides `ruby`, `gem`, etc. which are cleaned up prior to packaging.
-  # YJIT is disabled to avoid Rust dependency.
   - name: ruby
-    buildsystem: simple
-    builddir: true
-    config-opts: []
-    build-commands:
-      - ./configure --prefix=/app --disable-install-doc --disable-yjit
-      - make -j${FLATPAK_BUILDER_N_JOBS}
-      - make install
+    config-opts:
+      - --enable-shared
     sources:
       - type: archive
-        url: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.2.tar.xz
-        sha256: 4618db85bb9ec04d8152d0099db488694a3d3c4f52106625e4ad547f1318db87
+        url: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.3.tar.gz
+        sha256: 77964acc370d5c8375b9502e5ba6c13c03ef91ab9eb9f521c84fb42b9c9a6b0f
         x-checker-data:
           type: html
-          url: https://cache.ruby-lang.org/pub/ruby/
-          version-pattern: ruby-(4\.0\.[\d]+)\.tar\.xz
-          url-template: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-$version.tar.xz
+          url: https://www.ruby-lang.org/en/downloads/
+          pattern: (https://cache.ruby-lang.org/pub/ruby/[\d\.]+/ruby-([\d\.]+)\.tar\.gz)
+    cleanup:
+        - '*'
   - name: ocl-icd
     build-options:
       arch:


### PR DESCRIPTION
### Description

Proposing we revamp the Ruby build step (based on suggestions in https://github.com/flathub/org.jellyfin.JellyfinServer/pull/793#discussion_r3136117773) and at the same time fix the `x-data-checker` configuration I added when I added the Ruby build step as currently it is erroring out and hence why we haven't received a Ruby 4.0.3 bump and thus why I opened https://github.com/flathub/org.jellyfin.JellyfinServer/pull/792 which we shouldn't need.

While I was at it I bumped us to Ruby 4.0.3 as I'm confident this update checking configuration will work as expected according to my testing.

Related to
- https://github.com/flathub/org.jellyfin.JellyfinServer/pull/794

Follow up to
- https://github.com/flathub/org.jellyfin.JellyfinServer/pull/684

### Testing
#### Instructions

Instructions: install and run the flathub external data checker locally. ([docs](https://github.com/flathub-infra/flatpak-external-data-checker#use))

```console
flatpak install --from https://dl.flathub.org/repo/appstream/org.flathub.flatpak-external-data-checker.flatpakref

flatpak run org.flathub.flatpak-external-data-checker /home/larouxn/src/github.com/larouxn/org.jellyfin.JellyfinServer/org.jellyfin.JellyfinServer.yml
```

#### Output

**Before**

```console
ERROR   src.manifest: Failed to check archive ruby/ruby-4.0.2.tar.xz with HTMLChecker: Pattern 'ruby-(4\.0\.[\d]+)\.tar\.xz' didn't match anything
```

**After**

```console
INFO    src.manifest: Finished check [580/580] archive ruby/ruby-4.0.2.tar.xz (from org.jellyfin.JellyfinServer.yml)
OUTDATED: ruby-4.0.2.tar.xz
 Has a new version:
  URL:       https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.3.tar.xz
  MD5:       e182f8c1c1a5c2804b2783439a5ee1cc
  SHA1:      faf1f3df171d2160116d190ca32b6b00e0338bfa
  SHA256:    22cf6005d25bbe496b5ebe9224d63a1aaabfbfe02591bb5d612517c5a7836f29
  SHA512:    5816fb264ce76df59f4bfe0cadceb45025fada2e61f2c14024d6b03f63d304820cddf94afcf82a4951fd12f3b0d9148683f856f3f2245d56042fc8407b6cbff5
  Size:      17878572
  Version:   4.0.3
  Timestamp: 2026-04-21 09:02:55
```