### PR TITLE
Fix SPIRV-Tools and SVT-AV1 automatic update configs

### DIFF
--- a/org.jellyfin.JellyfinServer.yml
+++ b/org.jellyfin.JellyfinServer.yml
@@ -297,7 +297,7 @@ modules:
           tag-pattern: ^v([\d.]+)$
           # Known newer versions.
           versions:
-            - '!=': v2026.1 # FTBFS
+            '!=': v2026.1 # FTBFS
       - type: git
         url: https://github.com/KhronosGroup/SPIRV-Headers.git
         dest: third_party/spirv-headers
@@ -609,7 +609,7 @@ modules:
           tag-pattern: ^v([\d.]+)$
           # Known newer versions.
           versions:
-            - '!=': v4.0.0 # FTBFS
+            '!=': v4.0.0 # FTBFS
   - name: clinfo
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
### Description

Proposing we fix the SPIRV-Tools and SVT-AV1 `x-data-checker` configurations as they're erroring.

Related to
- https://github.com/flathub/org.jellyfin.JellyfinServer/pull/793

### Testing
#### Instructions

Instructions: install and run the flathub external data checker locally. ([docs](https://github.com/flathub-infra/flatpak-external-data-checker#use))

```console
flatpak install --from https://dl.flathub.org/repo/appstream/org.flathub.flatpak-external-data-checker.flatpakref

flatpak run org.flathub.flatpak-external-data-checker /home/larouxn/src/github.com/larouxn/org.jellyfin.JellyfinServer/org.jellyfin.JellyfinServer.yml
```

#### Output

**Before** (2 errors)

```console
ERROR   src.manifest: Failed to check git shaderc/SPIRV-Tools.git with GitChecker: Invalid metadata schema: [ordereddict({'!=': 'v2026.1'})] is not of type 'object'

Failed validating 'type' in schema['properties']['versions']:
    {'additionalProperties': False,
     'minProperties': 1,
     'properties': {'!=': {'type': 'string'},
                    '<': {'type': 'string'},
                    '<=': {'type': 'string'},
                    '==': {'type': 'string'},
                    '>': {'type': 'string'},
                    '>=': {'type': 'string'}},
     'type': 'object'}

On instance['versions']:
    [ordereddict({'!=': 'v2026.1'})]

ERROR   src.manifest: Failed to check git svt-av1/SVT-AV1.git with GitChecker: Invalid metadata schema: [ordereddict({'!=': 'v4.0.0'})] is not of type 'object'

Failed validating 'type' in schema['properties']['versions']:
    {'additionalProperties': False,
     'minProperties': 1,
     'properties': {'!=': {'type': 'string'},
                    '<': {'type': 'string'},
                    '<=': {'type': 'string'},
                    '==': {'type': 'string'},
                    '>': {'type': 'string'},
                    '>=': {'type': 'string'}},
     'type': 'object'}

On instance['versions']:
    [ordereddict({'!=': 'v4.0.0'})]
```

<img width="2880" height="1856" alt="Screenshot From 2026-04-24 16-03-58" src="https://github.com/user-attachments/assets/25660728-d70d-4374-adc1-d5f5626b9b18" />

**After** (0 errors)

<img width="2880" height="1856" alt="Screenshot From 2026-04-24 16-03-21" src="https://github.com/user-attachments/assets/233bc0b2-70d3-4566-b242-dd5fd5289ff7" />