### PR TITLE
Fix cron expression

### DIFF
--- a/.github/workflows/regenerate-sources.yml
+++ b/.github/workflows/regenerate-sources.yml
@@ -20,7 +20,7 @@ on:
   # Past releases usually happened late on Saturday
   #- cron: 15 6 * * SUN
   # Refresh sources only once per month to conserve resources.
-  - cron: 15 6 1-7 * SUN
+  - cron: 15 6 1 * *
   workflow_dispatch:
 env:
   MANIFEST: "main/org.jellyfin.JellyfinServer.yml"


### PR DESCRIPTION
The intended behavior was to run this on the first Sunday of a month. The actual behavior observed is, that it runs on every Sunday and all days between 1 and 7 of a month. So instead we just run it on the first of a month. Don't attempt to complicate the workflow any further by checking the date or day with script expressions.